### PR TITLE
ci(deps): actualizar actions (upload-artifact v6, github-script v8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         extra_system_packages: py3-pygments perl
         
     - name: Upload PDF artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: TFG-TFM_EPS_UA
         path: main.pdf
@@ -60,7 +60,7 @@ jobs:
         echo "RUN_URL=https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
         
     - name: Comment on PR
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |


### PR DESCRIPTION
## Cambios

- `actions/upload-artifact` v4 → v6
- `actions/github-script` v7 → v8

Actualización manual de las actions sugeridas por Dependabot.

Closes #9
Closes #10

## Summary by Sourcery

Update CI workflow to use newer GitHub Actions versions for artifact upload and PR commenting.

CI:
- Bump actions/upload-artifact from v4 to v6 in the build workflow.
- Bump actions/github-script from v7 to v8 in the build workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow versions to maintain compatibility and access the latest features in the CI/CD pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->