### PR TITLE
fix(docs): corregir errores markdownlint y activar reglas MD036/MD045/MD051/MD060

### DIFF
--- a/.github/agents/instalacion.md
+++ b/.github/agents/instalacion.md
@@ -215,7 +215,7 @@ Si el alumno quiere activar la detección de plagio con Copyleaks o Turnitin:
 ## Errores frecuentes y soluciones
 
 | Error | Causa | Solución |
-|---|---|---|
+| --- | --- | --- |
 | `python3: command not found` | Python no instalado | Instalar Python y añadir al PATH |
 | `pip: command not found` | pip no en PATH | Usar `python3 -m pip install ...` |
 | `lualatex: command not found` | LaTeX no instalado | Instalar TeX Live / MiKTeX |

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -78,7 +78,7 @@ Al cambiar `idioma` en `configuracion.tex`, actualizar también `lang=` en
 `cls/eps-metadata.tex`:
 
 | `idioma` | `lang=` |
-|---|---|
+| --- | --- |
 | `espanol` | `es-ES` |
 | `valenciano` | `ca-ES` |
 | `ingles` | `en-GB` |
@@ -361,7 +361,7 @@ services:
 Prefijos de etiquetas:
 
 | Prefijo | Elemento |
-|---|---|
+| --- | --- |
 | `chap:` | Capítulo |
 | `sec:` | Sección |
 | `fig:` | Figura |
@@ -433,7 +433,7 @@ make clean    # Limpiar auxiliares
 Pedir siempre las últimas 30 líneas de `main.log`.
 
 | Error | Solución |
-|---|---|
+| --- | --- |
 | `You must invoke LaTeX with -shell-escape` | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | `pip install latexminted` |
 | `Citation 'X' undefined` | Ejecutar `make` completo (biber) |

--- a/.herramientas/README.md
+++ b/.herramientas/README.md
@@ -5,7 +5,7 @@ Esta carpeta contiene herramientas internas para el mantenimiento de la plantill
 ## � Herramientas disponibles
 
 | Script | Descripción |
-|--------|-------------|
+| -------- | ------------- |
 | `actualizar_previews.py` | Genera e inserta previews de snippets LaTeX en la documentación |
 | `generar_portadas.py` | Genera las imágenes de portadas para el README principal |
 

--- a/.herramientas/README.md
+++ b/.herramientas/README.md
@@ -2,7 +2,7 @@
 
 Esta carpeta contiene herramientas internas para el mantenimiento de la plantilla.
 
-## � Herramientas disponibles
+## Herramientas disponibles
 
 | Script | Descripción |
 | -------- | ------------- |

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,10 +2,6 @@
   "default": true,
   "MD013": false,
   "MD033": false,
-  "MD036": false,
   "MD041": false,
-  "MD045": false,
-  "MD051": false,
-  "MD060": false,
   "MD024": { "siblings_only": true }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Escuela Politécnica Superior (EPS) de la Universidad de Alicante (UA).
 ### Archivos que el agente PUEDE editar libremente
 
 | Archivo / Directorio | Propósito |
-|---|---|
+| --- | --- |
 | `configuracion.tex` | Datos del autor, título, titulación, idioma |
 | `contenido/capitulos/*.tex` | Contenido de cada capítulo |
 | `contenido/anexos/*.tex` | Anexos (excepto `acronimos.tex` con cuidado) |
@@ -43,7 +43,7 @@ Escuela Politécnica Superior (EPS) de la Universidad de Alicante (UA).
 ### Archivos que el agente NO debe modificar sin instrucción explícita
 
 | Archivo | Razón |
-|---|---|
+| --- | --- |
 | `cls/eps-tfg.cls` | Clase principal; cambios rompen toda la plantilla |
 | `sty/*.sty` | Paquetes de estilo; requieren conocimiento profundo |
 | `sty/componentes/*.sty` | Módulos especializados |
@@ -249,7 +249,7 @@ Sufijo `Dark` para tema oscuro: `pythoncodeDark`, `jscodeDark`, etc.
 Prefijos de etiquetas a respetar:
 
 | Prefijo | Tipo de elemento |
-|---|---|
+| --- | --- |
 | `chap:` | Capítulo |
 | `sec:` | Sección |
 | `fig:` | Figura |
@@ -307,7 +307,7 @@ Formato de entrada en `referencias.bib`:
 ## Diagnóstico de errores frecuentes
 
 | Error en `.log` | Causa | Solución |
-|---|---|---|
+| --- | --- | --- |
 | `Undefined control sequence \EPSsetup` | `configuracion.tex` cargado antes de la clase | Verificar orden en `main.tex` |
 | `You must invoke LaTeX with -shell-escape` | Falta flag en compilación | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | `latexminted` no instalado | `pip install latexminted` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Cuando se cambia `idioma` en `configuracion.tex`, **también** hay que editar
 `cls/eps-metadata.tex` y cambiar el valor de `lang=`:
 
 | `idioma` en `\EPSsetup` | `lang=` en `eps-metadata.tex` |
-|---|---|
+| --- | --- |
 | `espanol` | `es-ES` |
 | `valenciano` | `ca-ES` |
 | `ingles` | `en-GB` |
@@ -407,7 +407,7 @@ Usar en el texto:
 Prefijos de etiquetas:
 
 | Prefijo | Elemento |
-|---|---|
+| --- | --- |
 | `chap:` | Capítulo |
 | `sec:` | Sección o subsección |
 | `fig:` | Figura |
@@ -475,7 +475,7 @@ Ver `docs/ACCESIBILIDAD.md` para la guía completa.
 Si el usuario reporta un error, pedir las últimas 30 líneas de `main.log`.
 
 | Error | Causa probable | Solución |
-|---|---|---|
+| --- | --- | --- |
 | `Undefined control sequence` | Comando no definido o paquete no cargado | Verificar módulo de componentes activo |
 | `You must invoke LaTeX with -shell-escape` | Falta flag | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | Python/minted no instalado | `pip install latexminted` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@
 - [Reportar bugs](#reportar-bugs)
 - [Proponer mejoras](#proponer-mejoras)
 
-## 📜 Código de Conducta
+## Código de Conducta📜
 
 Este proyecto sigue un código de conducta basado en el respeto mutuo. Por favor:
 
@@ -20,7 +20,7 @@ Este proyecto sigue un código de conducta basado en el respeto mutuo. Por favor
 - Acepta críticas constructivas con mentalidad abierta
 - Enfócate en lo que es mejor para la comunidad
 
-## 🤝 ¿Cómo puedo contribuir?
+## ¿Cómo puedo contribuir?🤝
 
 ### Formas de contribuir
 
@@ -49,7 +49,7 @@ Si usas ChatGPT, Claude, Copilot u otro asistente de IA para contribuir, el proy
 - `.github/copilot-instructions.md` - Contexto para GitHub Copilot
 - `docs/AI_CONTEXT.md` - Referencia técnica detallada
 
-## 🛠️ Configuración del entorno
+## Configuración del entorno🛠
 
 ### Requisitos
 
@@ -80,7 +80,7 @@ lualatex -shell-escape main.tex
 lualatex -shell-escape main.tex
 ```
 
-## 📝 Proceso de desarrollo
+## Proceso de desarrollo📝
 
 ### 1. Crear una rama
 
@@ -120,7 +120,7 @@ make
 3. Añade una entrada al `CHANGELOG.md` si corresponde
 4. Crea el Pull Request con una descripción clara
 
-## 📐 Guía de estilo
+## Guía de estilo📐
 
 ### LaTeX
 
@@ -151,7 +151,7 @@ recursos/     → Recursos estáticos
 - Incluye ejemplos de uso
 - Mantén el README actualizado
 
-## 🐛 Reportar bugs
+## Reportar bugs🐛
 
 Al reportar un bug, incluye:
 
@@ -188,7 +188,7 @@ Al reportar un bug, incluye:
 [Adjunta logs o MWE si es posible]
 ```
 
-## 💡 Proponer mejoras
+## Proponer mejoras💡
 
 Para proponer una mejora:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 📚 Plantilla TFG/TFM - Escuela Politécnica Superior
 
-**Universidad de Alicante**
+Universidad de Alicante
 
 [![LaTeX](https://img.shields.io/badge/LaTeX-LuaLaTeX-008080?logo=latex)](https://www.latex-project.org/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -51,7 +51,7 @@ Esta plantilla incluye una documentación exhaustiva para cada aspecto de tu TFG
 <summary><b>Ver lista de guías disponibles</b></summary>
 
 | Guía | Descripción |
-|------|-------------|
+| ------ | ------------- |
 | 📝 [Código Fuente](docs/CODIGO_FUENTE.md) | Insertar y resaltar código con minted (40+ lenguajes) |
 | 📊 [Figuras y Gráficas](docs/FIGURAS_GRAFICAS.md) | Crear gráficos con pgfplots y TikZ |
 | 🖼️ [Imágenes y Subfiguras](docs/IMAGENES_SUBFIGURAS.md) | Incluir imágenes, subfiguras y posicionamiento |
@@ -74,7 +74,7 @@ Esta plantilla incluye una documentación exhaustiva para cada aspecto de tu TFG
 ¿Usas ChatGPT, Claude, Copilot u otro asistente de IA? Este proyecto incluye archivos de contexto para que las IAs te ayuden mejor:
 
 | Archivo | Propósito |
-|---------|----------|
+| --------- | ---------- |
 | [AGENTS.md](AGENTS.md) | Instrucciones para agentes de código autónomos (Codex, Devin, etc.) |
 | [CLAUDE.md](CLAUDE.md) | Instrucciones específicas para Claude |
 | [.github/copilot-instructions.md](.github/copilot-instructions.md) | Instrucciones para GitHub Copilot |
@@ -84,7 +84,7 @@ Esta plantilla incluye una documentación exhaustiva para cada aspecto de tu TFG
 ### Agentes especializados
 
 | Agente | Para Copilot | Para Claude | Prompts |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Instalación guiada | [.github/agents/instalacion.md](.github/agents/instalacion.md) | [docs/agents/instalacion-claude.md](docs/agents/instalacion-claude.md) | [docs/agents/prompts-instalacion.md](docs/agents/prompts-instalacion.md) |
 | Redacción de capítulos | [.github/agents/redaccion.md](.github/agents/redaccion.md) | [docs/agents/redaccion-claude.md](docs/agents/redaccion-claude.md) | [docs/agents/prompts-redaccion.md](docs/agents/prompts-redaccion.md) |
 | Revisor tipo tribunal | [.github/agents/revisor.md](.github/agents/revisor.md) | [docs/agents/revisor-claude.md](docs/agents/revisor-claude.md) | [docs/agents/prompts-revisor.md](docs/agents/prompts-revisor.md) |
@@ -261,7 +261,7 @@ Toda la configuración se realiza en el archivo `configuracion.tex`:
 #### Grados
 
 | ID | Titulación |
-|----|------------|
+| ---- | ------------ |
 | `teleco` | Ingeniería en Sonido e Imagen en Telecomunicación |
 | `civil` | Ingeniería Civil |
 | `quimica` | Ingeniería Química |
@@ -274,7 +274,7 @@ Toda la configuración se realiza en el archivo `configuracion.tex`:
 #### Másteres
 
 | ID | Titulación |
-|----|------------|
+| ---- | ------------ |
 | `master-teleco` | Ingeniería de Telecomunicación |
 | `master-caminos` | Caminos, Canales y Puertos |
 | `master-edificacion` | Gestión de la Edificación |
@@ -302,39 +302,39 @@ Cada titulación tiene su propio diseño con colores y logotipos oficiales:
 #### Grados
 
 <p align="center">
-<img src=".github/images/portadas/portada_arquitectura_color.webp" width="12%" title="Grado en Arquitectura"></img>
-<img src=".github/images/portadas/portada_arquitectura-tecnica_color.webp" width="12%" title="Grado en Arquitectura Técnica"></img>
-<img src=".github/images/portadas/portada_civil_color.webp" width="12%" title="Grado en Ingeniería Civil"></img>
-<img src=".github/images/portadas/portada_informatica_color.webp" width="12%" title="Grado en Ingeniería Informática"></img>
-<img src=".github/images/portadas/portada_multimedia_color.webp" width="12%" title="Grado en Ingeniería Multimedia"></img>
-<img src=".github/images/portadas/portada_quimica_color.webp" width="12%" title="Grado en Ingeniería Química"></img>
-<img src=".github/images/portadas/portada_robotica_color.webp" width="12%" title="Grado en Ingeniería Robótica"></img>
-<img src=".github/images/portadas/portada_teleco_color.webp" width="12%" title="Grado en Ingeniería en Sonido e Imagen en Telecomunicación"></img>
+<img src=".github/images/portadas/portada_arquitectura_color.webp" width="12%" alt="Grado en Arquitectura" title="Grado en Arquitectura"></img>
+<img src=".github/images/portadas/portada_arquitectura-tecnica_color.webp" width="12%" alt="Grado en Arquitectura Técnica" title="Grado en Arquitectura Técnica"></img>
+<img src=".github/images/portadas/portada_civil_color.webp" width="12%" alt="Grado en Ingeniería Civil" title="Grado en Ingeniería Civil"></img>
+<img src=".github/images/portadas/portada_informatica_color.webp" width="12%" alt="Grado en Ingeniería Informática" title="Grado en Ingeniería Informática"></img>
+<img src=".github/images/portadas/portada_multimedia_color.webp" width="12%" alt="Grado en Ingeniería Multimedia" title="Grado en Ingeniería Multimedia"></img>
+<img src=".github/images/portadas/portada_quimica_color.webp" width="12%" alt="Grado en Ingeniería Química" title="Grado en Ingeniería Química"></img>
+<img src=".github/images/portadas/portada_robotica_color.webp" width="12%" alt="Grado en Ingeniería Robótica" title="Grado en Ingeniería Robótica"></img>
+<img src=".github/images/portadas/portada_teleco_color.webp" width="12%" alt="Grado en Ingeniería en Sonido e Imagen en Telecomunicación" title="Grado en Ingeniería en Sonido e Imagen en Telecomunicación"></img>
 </p>
 
 #### Másteres
 
 <p align="center">
-<img src=".github/images/portadas/portada_master-agua_color.webp" width="12%" title="Máster Universitario en Gestión Sostenible y Tecnologías del Agua"></img>
-<img src=".github/images/portadas/portada_master-caminos_color.webp" width="12%" title="Máster Universitario en Ingeniería de Caminos, Canales y Puertos"></img>
-<img src=".github/images/portadas/portada_master-ciberseguridad_color.webp" width="12%" title="Máster Universitario en Ciberseguridad"></img>
-<img src=".github/images/portadas/portada_master-edificacion_color.webp" width="12%" title="Máster Universitario en Gestión de la Edificación"></img>
-<img src=".github/images/portadas/portada_master-geologica_color.webp" width="12%" title="Máster Universitario en Ingeniería Geológica"></img>
-<img src=".github/images/portadas/portada_master-informatica_color.webp" width="12%" title="Máster Universitario en Ingeniería Informática"></img>
-<img src=".github/images/portadas/portada_master-materiales_color.webp" width="12%" title="Máster Universitario en Ingeniería de los Materiales, del Agua y del Terreno"></img>
-<img src=".github/images/portadas/portada_master-moviles_color.webp" width="12%" title="Máster Universitario en Desarrollo de Software para Dispositivos Móviles"></img>
-<img src=".github/images/portadas/portada_master-prevencion_color.webp" width="12%" title="Máster Universitario en Prevención de Riesgos Laborales"></img>
-<img src=".github/images/portadas/portada_master-quimica_color.webp" width="12%" title="Máster Universitario en Ingeniería Química"></img>
-<img src=".github/images/portadas/portada_master-robotica_color.webp" width="12%" title="Máster Universitario en Automática y Robótica"></img>
-<img src=".github/images/portadas/portada_master-teleco_color.webp" width="12%" title="Máster Universitario en Ingeniería de Telecomunicación"></img>
-<img src=".github/images/portadas/portada_master-web_color.webp" width="12%" title="Máster Universitario en Desarrollo de Aplicaciones y Servicios Web"></img>
+<img src=".github/images/portadas/portada_master-agua_color.webp" width="12%" alt="Máster Universitario en Gestión Sostenible y Tecnologías del Agua" title="Máster Universitario en Gestión Sostenible y Tecnologías del Agua"></img>
+<img src=".github/images/portadas/portada_master-caminos_color.webp" width="12%" alt="Máster Universitario en Ingeniería de Caminos, Canales y Puertos" title="Máster Universitario en Ingeniería de Caminos, Canales y Puertos"></img>
+<img src=".github/images/portadas/portada_master-ciberseguridad_color.webp" width="12%" alt="Máster Universitario en Ciberseguridad" title="Máster Universitario en Ciberseguridad"></img>
+<img src=".github/images/portadas/portada_master-edificacion_color.webp" width="12%" alt="Máster Universitario en Gestión de la Edificación" title="Máster Universitario en Gestión de la Edificación"></img>
+<img src=".github/images/portadas/portada_master-geologica_color.webp" width="12%" alt="Máster Universitario en Ingeniería Geológica" title="Máster Universitario en Ingeniería Geológica"></img>
+<img src=".github/images/portadas/portada_master-informatica_color.webp" width="12%" alt="Máster Universitario en Ingeniería Informática" title="Máster Universitario en Ingeniería Informática"></img>
+<img src=".github/images/portadas/portada_master-materiales_color.webp" width="12%" alt="Máster Universitario en Ingeniería de los Materiales, del Agua y del Terreno" title="Máster Universitario en Ingeniería de los Materiales, del Agua y del Terreno"></img>
+<img src=".github/images/portadas/portada_master-moviles_color.webp" width="12%" alt="Máster Universitario en Desarrollo de Software para Dispositivos Móviles" title="Máster Universitario en Desarrollo de Software para Dispositivos Móviles"></img>
+<img src=".github/images/portadas/portada_master-prevencion_color.webp" width="12%" alt="Máster Universitario en Prevención de Riesgos Laborales" title="Máster Universitario en Prevención de Riesgos Laborales"></img>
+<img src=".github/images/portadas/portada_master-quimica_color.webp" width="12%" alt="Máster Universitario en Ingeniería Química" title="Máster Universitario en Ingeniería Química"></img>
+<img src=".github/images/portadas/portada_master-robotica_color.webp" width="12%" alt="Máster Universitario en Automática y Robótica" title="Máster Universitario en Automática y Robótica"></img>
+<img src=".github/images/portadas/portada_master-teleco_color.webp" width="12%" alt="Máster Universitario en Ingeniería de Telecomunicación" title="Máster Universitario en Ingeniería de Telecomunicación"></img>
+<img src=".github/images/portadas/portada_master-web_color.webp" width="12%" alt="Máster Universitario en Desarrollo de Aplicaciones y Servicios Web" title="Máster Universitario en Desarrollo de Aplicaciones y Servicios Web"></img>
 </p>
 
 ### Ejemplo: Portada a color y B/N
 
 <p align="center">
-<img src=".github/images/portadas/portada_teleco_color.webp" width="30%"></img>
-<img src=".github/images/portadas/portada_teleco_bn.webp" width="30%"></img>
+<img src=".github/images/portadas/portada_teleco_color.webp" width="30%" alt="Portada a color - Grado en Ingeniería en Sonido e Imagen en Telecomunicación"></img>
+<img src=".github/images/portadas/portada_teleco_bn.webp" width="30%" alt="Portada en blanco y negro - Grado en Ingeniería en Sonido e Imagen en Telecomunicación"></img>
 </p>
 ### Comandos de Portada
 
@@ -362,21 +362,21 @@ La plantilla incluye estilos de código basados en **Visual Studio Code** con te
 ### Temas Disponibles
 
 | Tema | Descripción | Sufijo |
-|------|-------------|--------|
+| ------ | ------------- | -------- |
 | **VS Code Light** | Fondo blanco, ideal para impresión | (ninguno) |
 | **VS Code Dark** | Fondo oscuro, ideal para presentaciones | `Dark` |
 
 ### Variantes de Numeración
 
 | Variante | Descripción | Sufijo |
-|----------|-------------|--------|
+| ---------- | ------------- | -------- |
 | Con números | Muestra números de línea | (ninguno) |
 | Sin números | Oculta números de línea | `NN` |
 
 ### Lenguajes con Entornos Predefinidos
 
 | Lenguaje | Entorno Light | Entorno Dark | Icono |
-|----------|---------------|--------------|-------|
+| ---------- | --------------- | -------------- | ------- |
 | Python | `pythoncode` | `pythoncodeDark` | 🐍 |
 | JavaScript | `jscode` | `jscodeDark` | 📜 |
 | TypeScript | `tscode` | `tscodeDark` | 📜 |
@@ -671,7 +671,7 @@ Consulta la [Guía de Contribución](CONTRIBUTING.md) para más detalles.
 ### Herramientas incluidas en el proyecto
 
 | Herramienta | Cómo ejecutar | Para qué sirve |
-|-------------|---------------|----------------|
+| ------------- | --------------- | ---------------- |
 | `scripts/instalar.py` | `python3 scripts/instalar.py` | Comprueba e instala dependencias del entorno |
 | `scripts/revision-rapida.py` | `python3 scripts/revision-rapida.py` | Análisis estático del documento; genera `informe-revision.md` |
 | `.env.example` | Copiar a `.env` y rellenar | Credenciales para Copyleaks y Turnitin (opcional) |
@@ -681,7 +681,7 @@ La revisión estática también se ejecuta automáticamente en cada push/PR medi
 ### Editores recomendados
 
 | Editor | Plataforma | Descripción |
-|--------|------------|-------------|
+| -------- | ------------ | ------------- |
 | [VS Code](https://code.visualstudio.com/) + [LaTeX Workshop](https://marketplace.visualstudio.com/items?itemName=James-Yu.latex-workshop) | Win/Mac/Linux | Editor moderno con excelente soporte LaTeX |
 | [TeXstudio](https://www.texstudio.org/) | Win/Mac/Linux | Editor dedicado a LaTeX, muy completo |
 | [Texmaker](https://www.xm1math.net/texmaker/) | Win/Mac/Linux | Similar a TeXstudio, más sencillo |
@@ -690,7 +690,7 @@ La revisión estática también se ejecuta automáticamente en cada push/PR medi
 ### Herramientas útiles
 
 | Herramienta | Para qué sirve |
-|-------------|----------------|
+| ------------- | ---------------- |
 | [Detexify](https://detexify.kirelabs.org/) | Dibuja un símbolo → obtén el comando LaTeX |
 | [Tables Generator](https://www.tablesgenerator.com/) | Crea tablas visualmente |
 | [Mathpix](https://mathpix.com/) | Convierte imágenes de ecuaciones a LaTeX |
@@ -702,7 +702,7 @@ La revisión estática también se ejecuta automáticamente en cada push/PR medi
 ### Documentación y tutoriales
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [Overleaf Learn](https://www.overleaf.com/learn) | Tutoriales completos (EN/ES) |
 | [LaTeX Wikibook](https://en.wikibooks.org/wiki/LaTeX) | Referencia exhaustiva |
 | [TeX StackExchange](https://tex.stackexchange.com/) | Preguntas y respuestas |

--- a/cls/README.md
+++ b/cls/README.md
@@ -20,7 +20,7 @@ Este archivo contiene la clase LaTeX principal de la plantilla TFG/TFM.
 ### Tecnologías utilizadas
 
 | Tecnología | Uso |
-|------------|-----|
+| ------------ | ----- |
 | **expl3** | Programación LaTeX3 moderna |
 | **xparse** | Definición de comandos con sintaxis avanzada |
 | **l3keys2e** | Sistema de claves key=value |
@@ -67,7 +67,7 @@ eps-tfg.cls
 ### Variables principales
 
 | Variable | Tipo | Descripción |
-|----------|------|-------------|
+| ---------- | ------ | ------------- |
 | `\g__eps_titulo_tl` | token list | Título del trabajo |
 | `\g__eps_autor_tl` | token list | Nombre del autor |
 | `\g__eps_titulacion_tl` | token list | ID de titulación |
@@ -171,7 +171,7 @@ Cada titulación se define con:
 ## 🔗 Archivos relacionados
 
 | Archivo | Relación |
-|---------|----------|
+| --------- | ---------- |
 | `sty/eps-portadas.sty` | Define `\portadacolor` y `\portadabn` |
 | `sty/eps-codigo.sty` | Estilos para bloques de código |
 | `configuracion.tex` | Usuario llama a `\EPSsetup{}` |

--- a/docs/ACCESIBILIDAD.md
+++ b/docs/ACCESIBILIDAD.md
@@ -30,7 +30,7 @@ La accesibilidad en documentos PDF permite que personas con discapacidades visua
 ### Estándares relevantes
 
 | Estándar | Descripción |
-|----------|-------------|
+| ---------- | ------------- |
 | **PDF/UA-1** | ISO 14289-1:2014 - Accesibilidad universal para PDF |
 | **PDF/UA-2** | ISO 14289-2:2024 - Versión actualizada del estándar |
 | **WCAG 2.1** | Web Content Accessibility Guidelines (aplicable a PDFs) |
@@ -85,7 +85,7 @@ Para activar el etiquetado PDF/UA-2, añade el siguiente código **antes** de `\
 ### Opciones de idioma
 
 | Valor | Idioma |
-|-------|--------|
+| ------- | -------- |
 | `es-ES` | Español (España) |
 | `ca-ES` | Valenciano/Catalán |
 | `en-GB` | Inglés británico |
@@ -123,7 +123,7 @@ Las imágenes puramente decorativas deben marcarse como artefactos:
 ### Buenas prácticas para texto alternativo
 
 | ✅ Hacer | ❌ Evitar |
-|---------|----------|
+| --------- | ---------- |
 | Describir el **significado** de la imagen | Describir la apariencia visual |
 | Ser conciso pero completo | Texto excesivamente largo |
 | Incluir datos clave de gráficas | "Gráfica mostrando datos" |
@@ -192,7 +192,7 @@ Con LuaLaTeX y `unicode-math`, las ecuaciones se etiquetan automáticamente como
 ### Herramientas de validación
 
 | Herramienta | Descripción | Enlace |
-|-------------|-------------|--------|
+| ------------- | ------------- | -------- |
 | **Adobe Acrobat Pro** | Comprobador de accesibilidad integrado | [adobe.com](https://www.adobe.com/acrobat) |
 | **PAC 2024** | Verificador PDF/UA gratuito | [pdfua.foundation](https://pdfua.foundation/en/pac-download) |
 | **PAVE** | Validador online gratuito | [pave-pdf.org](https://pave-pdf.org/) |
@@ -214,7 +214,7 @@ Con LuaLaTeX y `unicode-math`, las ecuaciones se etiquetan automáticamente como
 ### Documentación oficial
 
 | Recurso | URL |
-|---------|-----|
+| --------- | ----- |
 | LaTeX Tagging Project | [latex3.github.io/tagging-project](https://latex3.github.io/tagging-project/documentation/usage-instructions) |
 | Overleaf - PDFs accesibles | [overleaf.com/learn](https://www.overleaf.com/learn/latex/Accessibility) |
 | PDF/UA Foundation | [pdfua.foundation](https://pdfua.foundation/) |

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -2,9 +2,9 @@
 
 Este documento proporciona información técnica detallada para que los asistentes de IA puedan dar respuestas precisas sobre esta plantilla LaTeX.
 
-## 📋 Índice
+## Índice📋
 
-- [📋 Índice](#-índice)
+- [📋 Índice](#índice)
   - [🏗️ Arquitectura de la Plantilla](#️-arquitectura-de-la-plantilla)
     - [Clase Principal: `eps-tfg.cls`](#clase-principal-eps-tfgcls)
     - [Paquetes de Estilo (`sty/`)](#paquetes-de-estilo-sty)

--- a/docs/AI_CONTEXT.md
+++ b/docs/AI_CONTEXT.md
@@ -4,8 +4,7 @@ Este documento proporciona información técnica detallada para que los asistent
 
 ## 📋 Índice
 
-- [� Contexto Técnico para IA - Plantilla TFG/TFM EPS UA](#-contexto-técnico-para-ia-plantilla-tfgtfm-eps-ua)
-  - [📋 Índice](#-índice)
+- [📋 Índice](#-índice)
   - [🏗️ Arquitectura de la Plantilla](#️-arquitectura-de-la-plantilla)
     - [Clase Principal: `eps-tfg.cls`](#clase-principal-eps-tfgcls)
     - [Paquetes de Estilo (`sty/`)](#paquetes-de-estilo-sty)
@@ -93,7 +92,7 @@ El usuario interactúa mediante:
 ### Paquetes de Estilo (`sty/`)
 
 | Archivo | Función |
-|---------|---------|
+| --------- | --------- |
 | `eps-portadas.sty` | Generación de portadas con TikZ |
 | `eps-fuentes.sty` | Configuración de tipografía |
 | `eps-colores.sty` | Paleta de colores por titulación |
@@ -108,7 +107,7 @@ El usuario interactúa mediante:
 ### Información del Documento
 
 | Clave | Tipo | Obligatorio | Descripción |
-|-------|------|-------------|-------------|
+| ------- | ------ | ------------- | ------------- |
 | `titulo` | texto | ✅ | Título principal del trabajo |
 | `subtitulo` | texto | ❌ | Subtítulo opcional |
 | `fecha` | texto | ✅ | Fecha de presentación (ej: "Junio 2026") |
@@ -117,7 +116,7 @@ El usuario interactúa mediante:
 ### Información del Autor
 
 | Clave | Tipo | Obligatorio | Descripción |
-|-------|------|-------------|-------------|
+| ------- | ------ | ------------- | ------------- |
 | `autor` | texto | ✅ | Nombre completo del autor |
 | `genero` | m/f/n | ❌ | Género para etiquetas (default: m) |
 | `email` | texto | ❌ | Email institucional |
@@ -125,7 +124,7 @@ El usuario interactúa mediante:
 ### Información del Tutor
 
 | Clave | Tipo | Obligatorio | Descripción |
-|-------|------|-------------|-------------|
+| ------- | ------ | ------------- | ------------- |
 | `tutor` | texto | ✅ | Nombre completo del tutor |
 | `tutor-genero` | m/f/n | ❌ | Género del tutor (default: m) |
 | `tutor-departamento` | texto | ✅ | Departamento del tutor |
@@ -134,7 +133,7 @@ El usuario interactúa mediante:
 ### Información del Cotutor (opcional)
 
 | Clave | Tipo | Obligatorio | Descripción |
-|-------|------|-------------|-------------|
+| ------- | ------ | ------------- | ------------- |
 | `cotutor` | texto | ❌ | Nombre completo del cotutor |
 | `cotutor-genero` | m/f/n | ❌ | Género del cotutor (default: m) |
 | `cotutor-departamento` | texto | ❌ | Departamento del cotutor |
@@ -143,14 +142,14 @@ El usuario interactúa mediante:
 ### Metadatos
 
 | Clave | Tipo | Obligatorio | Descripción |
-|-------|------|-------------|-------------|
+| ------- | ------ | ------------- | ------------- |
 | `palabras-clave` | lista | ❌ | Palabras clave en español |
 | `keywords` | lista | ❌ | Keywords en inglés |
 
 ### Idioma
 
 | Clave | Tipo | Obligatorio | Descripción |
-|-------|------|-------------|-------------|
+| ------- | ------ | ------------- | ------------- |
 | `idioma` | texto | ❌ | Idioma del documento: `espanol` (defecto), `valenciano`, `ingles` |
 
 > ⚠️ **Importante:** Si se cambia el idioma, también se debe actualizar el código de idioma en `cls/eps-metadata.tex` para que los metadatos PDF/UA-2 sean correctos:
@@ -166,7 +165,7 @@ El usuario interactúa mediante:
 ### Grados (TFG)
 
 | ID | Nombre Completo | Color Principal |
-|----|-----------------|-----------------|
+| ---- | ----------------- | ----------------- |
 | `arquitectura` | Grado en Fundamentos de la Arquitectura | #B5121B |
 | `arquitectura-tecnica` | Grado en Arquitectura Técnica | #BA6831 |
 | `civil` | Grado en Ingeniería Civil | #6E9B3A |
@@ -179,7 +178,7 @@ El usuario interactúa mediante:
 ### Másteres (TFM)
 
 | ID | Nombre Completo |
-|----|-----------------|
+| ---- | ----------------- |
 | `master-agua` | Máster en Gestión Sostenible del Agua |
 | `master-caminos` | Máster en Ingeniería de Caminos, Canales y Puertos |
 | `master-ciberseguridad` | Máster en Ciberseguridad |
@@ -391,7 +390,7 @@ En `main.tex`:
 ### Comandos de cita
 
 | Comando | Resultado | Uso |
-|---------|-----------|-----|
+| --------- | ----------- | ----- |
 | `\parencite{key}` | (Autor, 2024) | Cita parentética |
 | `\textcite{key}` | Autor (2024) | Cita textual |
 | `\cite{key}` | [1] | Cita numérica |
@@ -574,7 +573,7 @@ $lualatex = 'lualatex -shell-escape %O %S';
 ### Errores de compilación
 
 | Error | Causa probable | Solución |
-|-------|---------------|----------|
+| ------- | --------------- | ---------- |
 | `Undefined control sequence` | Comando no definido | Verificar paquete cargado |
 | `Missing $ inserted` | Símbolo matemático fuera de math mode | Añadir `$...$` |
 | `File not found` | Ruta incorrecta | Verificar nombre y ubicación |
@@ -584,7 +583,7 @@ $lualatex = 'lualatex -shell-escape %O %S';
 ### Errores de minted
 
 | Error | Solución |
-|-------|----------|
+| ------- | ---------- |
 | `You must invoke LaTeX with -shell-escape` | Añadir `-shell-escape` al comando |
 | `Pygments not found` | Instalar: `pip install latexminted` |
 | `Cannot find ... lexer` | Verificar nombre del lenguaje |
@@ -592,7 +591,7 @@ $lualatex = 'lualatex -shell-escape %O %S';
 ### Errores de bibliografía
 
 | Error | Solución |
-|-------|----------|
+| ------- | ---------- |
 | `Citation undefined` | Ejecutar `biber main` |
 | `I couldn't open file` | Verificar nombre del archivo .bib |
 | `Biber error` | Revisar sintaxis del archivo .bib |
@@ -616,7 +615,7 @@ Para generar PDFs que cumplan con PDF/UA-2, añadir antes de `\documentclass`:
 ### Requisitos
 
 | Requisito | Descripción |
-|-----------|-------------|
+| ----------- | ------------- |
 | LuaLaTeX | Obligatorio para MathML automático |
 | TeX Live 2025+ | Soporte completo del LaTeX Tagging Project |
 | Texto alternativo | Usar `alt={...}` en `\includegraphics` |

--- a/docs/AI_WORKFLOWS.md
+++ b/docs/AI_WORKFLOWS.md
@@ -57,7 +57,7 @@ la referencia técnica de `AI_CONTEXT.md`.
 **Titulaciones más comunes:**
 
 | Titulación | ID |
-|---|---|
+| --- | --- |
 | Ingeniería Informática | `informatica` |
 | Ingeniería en Sonido e Imagen | `teleco` |
 | Ingeniería Civil | `civil` |
@@ -323,7 +323,7 @@ El Código~\ref{cod:clasificador} muestra la implementación del clasificador.
 **Lenguajes disponibles:**
 
 | Entorno | Lenguaje |
-|---|---|
+| --- | --- |
 | `pythoncode` | Python |
 | `jscode` | JavaScript |
 | `cppcode` | C++ |
@@ -372,7 +372,7 @@ Añadir `Dark` al nombre para tema oscuro: `pythoncodeDark`, `jscodeDark`.
    Tabla de correspondencia:
 
    | `idioma` | `lang=` |
-   |---|---|
+   | --- | --- |
    | `espanol` | `es-ES` |
    | `valenciano` | `ca-ES` |
    | `ingles` | `en-GB` |
@@ -408,7 +408,7 @@ Añadir `Dark` al nombre para tema oscuro: `pythoncodeDark`, `jscodeDark`.
 **Opciones disponibles:**
 
 | Opción | Módulos incluidos | Para titulaciones |
-|---|---|---|
+| --- | --- | --- |
 | *(sin opción)* | Solo comunes | Cualquiera |
 | `[software]` | Comunes + Software | Informática, Multimedia, Robótica |
 | `[telecom]` | Comunes + Telecom | Telecomunicaciones |
@@ -483,7 +483,7 @@ grep -n "Error\|error\|Warning" main.log | grep -v "^#" | head -30
 1. Identificar el tipo de error:
 
 | Síntoma | Causa | Solución |
-|---|---|---|
+| --- | --- | --- |
 | `Undefined control sequence \nombre` | Comando no definido | Verificar que el módulo de componentes está activo; revisar ortografía |
 | `You must invoke LaTeX with -shell-escape` | Falta flag | Usar `make` en lugar de `lualatex` directo |
 | `Pygments not found` / `latexminted` | Python no instalado | `pip install latexminted` |

--- a/docs/BIBLIOGRAFIA.md
+++ b/docs/BIBLIOGRAFIA.md
@@ -153,7 +153,7 @@ Y se carga en `main.tex` con:
 ### Campos comunes
 
 | Campo | Descripción | Ejemplo |
-|-------|-------------|---------|
+| ------- | ------------- | --------- |
 | `author` | Autor(es) | `{García, Juan and López, María}` |
 | `title` | Título | `{Título del trabajo}` |
 | `year` | Año | `{2024}` |
@@ -509,7 +509,7 @@ Como indica García (\citeyear{garcia2024}), el método...
 ### Estilos disponibles
 
 | Estilo | Descripción | Ejemplo de cita |
-|--------|-------------|-----------------|
+| -------- | ------------- | ----------------- |
 | `apa` | American Psychological Association | (García, 2024) |
 | `ieee` | IEEE (numérico) | [1] |
 | `chicago-authordate` | Chicago autor-fecha | (García 2024) |
@@ -879,7 +879,7 @@ Como se indica en \parencite[p.~45]{pressman2020}, el proceso de desarrollo debe
 ### Documentación oficial
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [BibLaTeX en CTAN](https://ctan.org/pkg/biblatex) | Documentación completa del paquete |
 | [Biber en CTAN](https://ctan.org/pkg/biber) | Documentación del procesador de bibliografía |
 | [biblatex-apa](https://ctan.org/pkg/biblatex-apa) | Estilo APA 7ª edición |
@@ -893,7 +893,7 @@ Como se indica en \parencite[p.~45]{pressman2020}, el proceso de desarrollo debe
 ### Herramientas de gestión bibliográfica
 
 | Herramienta | Descripción |
-|-------------|-------------|
+| ------------- | ------------- |
 | [JabRef](https://www.jabref.org/) | Gestor de referencias gratuito para BibLaTeX |
 | [Zotero](https://www.zotero.org/) + [Better BibTeX](https://retorque.re/zotero-better-bibtex/) | Gestor con exportación mejorada |
 | [doi2bib](https://www.doi2bib.org/) | Genera entrada BibTeX desde DOI |
@@ -907,7 +907,7 @@ Como se indica en \parencite[p.~45]{pressman2020}, el proceso de desarrollo debe
 ### Versiones actuales (TeX Live 2025)
 
 | Componente | Versión | Fecha |
-|------------|---------|-------|
+| ------------ | --------- | ------- |
 | BibLaTeX | 3.21 | Julio 2025 |
 | Biber | 2.21 | Julio 2025 |
 

--- a/docs/CODIGO_FUENTE.md
+++ b/docs/CODIGO_FUENTE.md
@@ -86,7 +86,7 @@ pip install latexminted
 ### Lenguajes de programación
 
 | Lenguaje | Light | Light (sin líneas) | Dark | Dark (sin líneas) |
-|----------|-------|-------------------|------|-------------------|
+| ---------- | ------- | ------------------- | ------ | ------------------- |
 | Python | `pythoncode` | `pythoncodeNN` | `pythoncodeDark` | `pythoncodeDarkNN` |
 | JavaScript | `jscode` | `jscodeNN` | `jscodeDark` | `jscodeDarkNN` |
 | TypeScript | `tscode` | `tscodeNN` | `tscodeDark` | `tscodeDarkNN` |
@@ -112,7 +112,7 @@ pip install latexminted
 ### Web y markup
 
 | Lenguaje | Light | Light (sin líneas) | Dark | Dark (sin líneas) |
-|----------|-------|-------------------|------|-------------------|
+| ---------- | ------- | ------------------- | ------ | ------------------- |
 | HTML | `htmlcode` | `htmlcodeNN` | `htmlcodeDark` | `htmlcodeDarkNN` |
 | CSS | `csscode` | `csscodeNN` | `csscodeDark` | `csscodeDarkNN` |
 | SASS | `sasscode` | `sasscodeNN` | - | - |
@@ -126,7 +126,7 @@ pip install latexminted
 ### Shell y sistema
 
 | Lenguaje | Light | Light (sin líneas) | Dark | Dark (sin líneas) |
-|----------|-------|-------------------|------|-------------------|
+| ---------- | ------- | ------------------- | ------ | ------------------- |
 | Bash | `bashcode` | `bashcodeNN` | `bashcodeDark` | `bashcodeDarkNN` |
 | PowerShell | `pscode` | `pscodeNN` | - | - |
 | Makefile | `makecode` | `makecodeNN` | - | - |
@@ -139,7 +139,7 @@ pip install latexminted
 ### Bases de datos y redes
 
 | Lenguaje | Light | Light (sin líneas) | Dark | Dark (sin líneas) |
-|----------|-------|-------------------|------|-------------------|
+| ---------- | ------- | ------------------- | ------ | ------------------- |
 | SQL | `sqlcode` | `sqlcodeNN` | `sqlcodeDark` | `sqlcodeDarkNN` |
 | Nginx | `nginxcode` | `nginxcodeNN` | `nginxcodeDark` | `nginxcodeDarkNN` |
 | Apache | `apachecode` | `apachecodeNN` | `apachecodeDark` | `apachecodeDarkNN` |
@@ -148,7 +148,7 @@ pip install latexminted
 ### Hardware y bajo nivel
 
 | Lenguaje | Light | Light (sin líneas) | Dark | Dark (sin líneas) |
-|----------|-------|-------------------|------|-------------------|
+| ---------- | ------- | ------------------- | ------ | ------------------- |
 | Assembly | `asmcode` | `asmcodeNN` | `asmcodeDark` | `asmcodeDarkNN` |
 | VHDL | `vhdlcode` | `vhdlcodeNN` | `vhdlcodeDark` | `vhdlcodeDarkNN` |
 | Verilog | `verilogcode` | `verilogcodeNN` | `verilogcodeDark` | `verilogcodeDarkNN` |
@@ -156,7 +156,7 @@ pip install latexminted
 ### Genéricos (cualquier lenguaje)
 
 | Variante | Entorno |
-|----------|---------|
+| ---------- | --------- |
 | Light con líneas | `\begin{codigo}{lenguaje}...\end{codigo}` |
 | Light sin líneas | `\begin{codigoNN}{lenguaje}...\end{codigoNN}` |
 | Dark con líneas | `\begin{codigoDark}{lenguaje}...\end{codigoDark}` |
@@ -324,7 +324,7 @@ def ejemplo():
 ### Todas las opciones de minted disponibles
 
 | Opción | Descripción | Ejemplo |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `fontsize` | Tamaño de fuente | `\small`, `\footnotesize`, `\scriptsize` |
 | `linenos` | Mostrar números de línea | `true`, `false` |
 | `firstnumber` | Número de la primera línea | `100` |
@@ -345,7 +345,7 @@ def ejemplo():
 ### Opciones de tcolorbox
 
 | Opción | Descripción | Ejemplo |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `title` | Título del bloque | `Mi código` |
 | `label` | Etiqueta para referencias | `cod:mi-codigo` |
 | `colback` | Color de fondo | `white` |
@@ -815,7 +815,7 @@ DIJKSTRA(G, origen):
 ### Documentación oficial
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [minted en CTAN](https://ctan.org/pkg/minted) | Documentación oficial del paquete |
 | [latexminted en PyPI](https://pypi.org/project/latexminted/) | Ejecutable Python para minted 3.x |
 | [tcolorbox en CTAN](https://ctan.org/pkg/tcolorbox) | Documentación de cajas personalizadas |
@@ -823,7 +823,7 @@ DIJKSTRA(G, origen):
 ### Pygments
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [Pygments Home](https://pygments.org/) | Sitio oficial |
 | [Lista de Lexers](https://pygments.org/docs/lexers/) | Lenguajes soportados |
 | [Estilos disponibles](https://pygments.org/styles/) | Temas de resaltado |
@@ -831,7 +831,7 @@ DIJKSTRA(G, origen):
 ### Compatibilidad con plataformas
 
 | Plataforma | Soporte minted 3.x | Notas |
-|------------|---------------------|-------|
+| ------------ | --------------------- | ------- |
 | **TeX Live 2025** | ✅ Completo | `-shell-escape` opcional en TL2024+ |
 | **Overleaf** | ✅ Completo | Funciona automáticamente |
 | **arXiv** | ✅ Desde sept. 2025 | Ver [arXiv TeX Live 2025](https://info.arxiv.org/help/faq/texlive.html) |

--- a/docs/COMPONENTES.md
+++ b/docs/COMPONENTES.md
@@ -17,7 +17,7 @@ Este sistema proporciona componentes visuales especializados para diferentes dis
   - [Otros componentes comunes](#otros-componentes-comunes)
 - [Componentes de Software (`eps-software.sty`)](#componentes-de-software-eps-softwaresty)
   - [API REST Endpoints](#api-rest-endpoints)
-  - [Terminal / CLI](#terminal-cli)
+  - [Terminal CLI](#terminal-cli)
   - [Base de datos](#base-de-datos)
   - [UML](#uml)
   - [Git y control de versiones](#git-y-control-de-versiones)
@@ -540,7 +540,7 @@ Cargar con: `\usepackage[software]{eps-componentes}`
 
 ---
 
-### Terminal / CLI
+### Terminal CLI
 
 #### `terminal` - Bloque de terminal
 
@@ -1430,7 +1430,7 @@ Tabla estilo booktabs con cálculo automático de nivel de riesgo y soporte para
 Todos los componentes usan una paleta unificada:
 
 | Color | Código | Uso | Muestra |
-|-------|--------|-----|---------|
+| ------- | -------- | ----- | --------- |
 | `eps-primary` | `#2563EB` | Azul principal | 🔵 |
 | `eps-secondary` | `#7C3AED` | Violeta | 🟣 |
 | `eps-success` | `#059669` | Verde éxito | 🟢 |

--- a/docs/ECUACIONES.md
+++ b/docs/ECUACIONES.md
@@ -1224,7 +1224,7 @@ Las ecuaciones de Maxwell en forma diferencial son:
 ### Documentación oficial
 
 | Paquete | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [amsmath](https://ctan.org/pkg/amsmath) | Entornos de ecuaciones estándar |
 | [mathtools](https://ctan.org/pkg/mathtools) | Extensiones de amsmath |
 | [unicode-math](https://ctan.org/pkg/unicode-math) | Fuentes matemáticas Unicode (LuaLaTeX) |
@@ -1234,7 +1234,7 @@ Las ecuaciones de Maxwell en forma diferencial son:
 ### Herramientas y referencias
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [Detexify](https://detexify.kirelabs.org/) | Dibuja símbolos para encontrar su código |
 | [LaTeX Math Symbols](https://oeis.org/wiki/List_of_LaTeX_mathematical_symbols) | Lista completa de símbolos |
 | [Mathpix](https://mathpix.com/) | Convierte imágenes de ecuaciones a LaTeX |

--- a/docs/FIGURAS_GRAFICAS.md
+++ b/docs/FIGURAS_GRAFICAS.md
@@ -543,7 +543,7 @@ Esta plantilla carga los siguientes paquetes para gráficas:
 ### Opciones del eje (axis)
 
 | Opción | Descripción | Valores |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `width` | Ancho de la gráfica | `10cm`, `0.8\textwidth` |
 | `height` | Alto de la gráfica | `6cm`, `0.5\textwidth` |
 | `xlabel` | Etiqueta eje X | Texto o matemáticas `{$x$}` |
@@ -561,7 +561,7 @@ Esta plantilla carga los siguientes paquetes para gráficas:
 ### Opciones de plot (addplot)
 
 | Opción | Descripción | Valores |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `color` | Color de la línea | `blue`, `red`, `rgb,255:red,100;green,50;blue,0` |
 | `thick` | Grosor de línea | `ultra thin`, `thin`, `thick`, `ultra thick` |
 | `line width` | Grosor específico | `1pt`, `2mm` |
@@ -827,7 +827,7 @@ Esta plantilla carga los siguientes paquetes para gráficas:
 ### Opciones de lectura de tabla
 
 | Opción | Descripción | Ejemplo |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `col sep` | Separador de columnas | `comma`, `space`, `tab`, `semicolon` |
 | `x` | Columna para X | `tiempo` |
 | `y` | Columna para Y | `valor` |
@@ -1040,7 +1040,7 @@ La plantilla incluye el paquete `pgf-pie` para gráficas circulares.
 ### Opciones de pgf-pie
 
 | Opción | Descripción | Valores |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `text` | Posición del texto | `label`, `pin`, `legend`, `inside` |
 | `radius` | Radio del círculo | `2`, `3cm` |
 | `explode` | Separación de sectores | `0.1` |
@@ -1301,7 +1301,7 @@ La plantilla incluye el paquete `pgf-pie` para gráficas circulares.
 ### Documentación oficial
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [PGFPlots Manual](https://ctan.org/pkg/pgfplots) | Documentación completa |
 | [TikZ & PGF Manual](https://tikz.dev/) | Documentación oficial interactiva |
 | [TikZ en CTAN](https://ctan.org/pkg/pgf) | Paquete base |
@@ -1311,7 +1311,7 @@ La plantilla incluye el paquete `pgf-pie` para gráficas circulares.
 ### Galerías y ejemplos
 
 | Recurso | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [TeXample.net TikZ](https://texample.net/tikz/examples/) | Galería de ejemplos TikZ |
 | [pgfplots.net](http://pgfplots.net/) | Ejemplos de PGFPlots |
 | [Overleaf: TikZ](https://www.overleaf.com/learn/latex/TikZ_package) | Tutorial completo |
@@ -1320,7 +1320,7 @@ La plantilla incluye el paquete `pgf-pie` para gráficas circulares.
 ### Versiones actuales (TeX Live 2025)
 
 | Componente | Versión |
-|------------|----------|
+| ------------ | ---------- |
 | TikZ/PGF | 3.1.11a |
 | PGFPlots | 1.18.2 |
 

--- a/docs/GLOSARIOS_ACRONIMOS.md
+++ b/docs/GLOSARIOS_ACRONIMOS.md
@@ -110,7 +110,7 @@ El paquete `glossaries` permite:
 ### Opciones del paquete
 
 | Opción | Descripción |
-|--------|-------------|
+| -------- | ------------- |
 | `acronym` | Crear lista separada de acrónimos |
 | `symbols` | Crear lista separada de símbolos |
 | `toc` | Incluir glosarios en el índice |
@@ -193,7 +193,7 @@ Y cargarlo en el preámbulo:
 ### Campos disponibles
 
 | Campo | Descripción |
-|-------|-------------|
+| ------- | ------------- |
 | `name` | Nombre del término (obligatorio) |
 | `description` | Definición (obligatorio) |
 | `plural` | Forma plural |
@@ -459,7 +459,7 @@ La velocidad \gls{sym:velocidad} se mide en m/s.
 ```
 
 | Estilo | Descripción |
-|--------|-------------|
+| -------- | ------------- |
 | `list` | Lista simple |
 | `listgroup` | Lista con grupos por letra |
 | `long` | Tabla con dos columnas |

--- a/docs/GUIA_PRINCIPIANTES.md
+++ b/docs/GUIA_PRINCIPIANTES.md
@@ -52,8 +52,7 @@ Si vienes de Word, Google Docs o similar, LaTeX puede parecer intimidante al pri
 - [❗ Errores comunes y soluciones](#-errores-comunes-y-soluciones)
   - ["File not found" / "Archivo no encontrado"](#file-not-found--archivo-no-encontrado)
   - ["Undefined control sequence"](#undefined-control-sequence)
-  <!-- markdownlint-disable-next-line MD051 -->
-  - ["Missing $ inserted" / "Falta $"](#missing-inserted-falta-)
+  - [Missing dollar sign inserted](#missing-dollar-sign-inserted)
   - [La bibliografía no aparece](#la-bibliografía-no-aparece)
   - [El código no tiene colores](#el-código-no-tiene-colores)
   - [Compilación muy lenta](#compilación-muy-lenta)
@@ -542,7 +541,7 @@ Esto le enseñará a la IA qué paquetes usamos, cómo se hacen las portadas y l
 - Revisa que no haya errores tipográficos
 - Asegúrate de que el paquete necesario está cargado
 
-### "Missing $ inserted" / "Falta $"
+### Missing dollar sign inserted
 
 **Causa:** Hay contenido matemático fuera del modo matemático.
 

--- a/docs/GUIA_PRINCIPIANTES.md
+++ b/docs/GUIA_PRINCIPIANTES.md
@@ -20,12 +20,12 @@ Si vienes de Word, Google Docs o similar, LaTeX puede parecer intimidante al pri
   - [Entornos](#entornos)
   - [Comentarios](#comentarios)
 - [💻 Instalación paso a paso](#-instalación-paso-a-paso)
-  - [Opción 1: Overleaf (sin instalar nada) ⭐ Recomendado para empezar](#opción-1-overleaf-sin-instalar-nada-recomendado-para-empezar)
+  - [Opción 1: Overleaf (sin instalar nada) Recomendado para empezar ⭐](#opción-1-overleaf-sin-instalar-nada-recomendado-para-empezar)
   - [Opción 2: Instalación local en Windows](#opción-2-instalación-local-en-windows)
   - [Opción 3: Instalación local en macOS](#opción-3-instalación-local-en-macos)
   - [Opción 4: Instalación local en Linux (Ubuntu/Debian)](#opción-4-instalación-local-en-linux-ubuntudebian)
-- [✍️ Eligiendo un editor](#-eligiendo-un-editor)
-  - [VS Code + LaTeX Workshop ⭐ Recomendado](#vs-code-latex-workshop-recomendado)
+- [✍️ Eligiendo un editor](#eligiendo-un-editor)
+  - [VS Code + LaTeX Workshop Recomendado ⭐](#vs-code--latex-workshop-recomendado)
   - [TeXstudio - Alternativa popular](#texstudio---alternativa-popular)
   - [Texmaker - Similar a TeXstudio](#texmaker---similar-a-texstudio)
   - [Comparativa rápida](#comparativa-rápida)
@@ -34,7 +34,7 @@ Si vienes de Word, Google Docs o similar, LaTeX puede parecer intimidante al pri
   - [Con TeXstudio/Texmaker](#con-texstudiotexmaker)
   - [Desde terminal](#desde-terminal)
   - [¿Por qué hay que compilar varias veces?](#por-qué-hay-que-compilar-varias-veces)
-- [✏️ Escribiendo contenido](#-escribiendo-contenido)
+- [✏️ Escribiendo contenido](#escribiendo-contenido)
   - [Lo que debes editar](#lo-que-debes-editar)
   - [Ejemplo: Escribir un capítulo](#ejemplo-escribir-un-capítulo)
   - [Añadir figuras](#añadir-figuras)
@@ -50,8 +50,9 @@ Si vienes de Word, Google Docs o similar, LaTeX puede parecer intimidante al pri
   - [Proporcionar contexto](#proporcionar-contexto)
   - [Qué puedes pedirles](#qué-puedes-pedirles)
 - [❗ Errores comunes y soluciones](#-errores-comunes-y-soluciones)
-  - ["File not found" / "Archivo no encontrado"](#file-not-found-archivo-no-encontrado)
+  - ["File not found" / "Archivo no encontrado"](#file-not-found--archivo-no-encontrado)
   - ["Undefined control sequence"](#undefined-control-sequence)
+  <!-- markdownlint-disable-next-line MD051 -->
   - ["Missing $ inserted" / "Falta $"](#missing-inserted-falta-)
   - [La bibliografía no aparece](#la-bibliografía-no-aparece)
   - [El código no tiene colores](#el-código-no-tiene-colores)
@@ -76,7 +77,7 @@ Este es un párrafo de ejemplo con una ecuación: $E = mc^2$
 ### ¿Por qué usarlo para el TFG/TFM?
 
 | Ventaja | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | 📐 **Formato profesional** | Genera documentos con tipografía y maquetación de calidad editorial |
 | 🔢 **Ecuaciones** | El mejor sistema para escribir fórmulas matemáticas |
 | 📚 **Bibliografía** | Gestión automática de citas y referencias |
@@ -96,7 +97,7 @@ Hay una **curva de aprendizaje inicial**. Necesitas aprender algunos comandos b�
 ### Archivos y extensiones
 
 | Extensión | Qué es |
-|-----------|--------|
+| ----------- | -------- |
 | `.tex` | Archivo de código LaTeX (tu contenido) |
 | `.pdf` | El documento final generado |
 | `.bib` | Base de datos de bibliografía |
@@ -177,7 +178,7 @@ Si prefieres que una IA te guíe paso a paso, usa el **agente de instalación**:
 
 Si prefieres instalar manualmente, sigue las opciones a continuación.
 
-### Opción 1: Overleaf (sin instalar nada) ⭐ Recomendado para empezar
+### Opción 1: Overleaf (sin instalar nada) Recomendado para empezar⭐
 
 [Overleaf](https://www.overleaf.com) es un editor LaTeX online. No necesitas instalar nada.
 
@@ -243,9 +244,9 @@ pip3 install latexminted
 
 ---
 
-## ✍️ Eligiendo un editor
+## Eligiendo un editor✍
 
-### VS Code + LaTeX Workshop ⭐ Recomendado
+### VS Code + LaTeX Workshop Recomendado⭐
 
 **Visual Studio Code** es un editor moderno y gratuito. Con la extensión **LaTeX Workshop** se convierte en un excelente entorno para LaTeX.
 
@@ -290,7 +291,7 @@ pip3 install latexminted
 ### Comparativa rápida
 
 | Editor | Facilidad | Características | Para quién |
-|--------|-----------|-----------------|------------|
+| -------- | ----------- | ----------------- | ------------ |
 | **Overleaf** | ⭐⭐⭐⭐⭐ | Online, colaborativo | Principiantes, equipos |
 | **VS Code** | ⭐⭐⭐⭐ | Muy extensible | Programadores, avanzados |
 | **TeXstudio** | ⭐⭐⭐⭐ | Todo incluido | Uso general |
@@ -340,12 +341,12 @@ LaTeX necesita múltiples pasadas para:
 
 ---
 
-## ✏️ Escribiendo contenido
+## Escribiendo contenido✏
 
 ### Lo que debes editar
 
 | Archivo | Qué contiene |
-|---------|--------------|
+| --------- | -------------- |
 | `configuracion.tex` | Tu nombre, título, titulación, tutor... |
 | `contenido/capitulos/*.tex` | El texto de cada capítulo |
 | `contenido/anexos/*.tex` | Anexos |
@@ -452,7 +453,7 @@ Según García \cite{garcia2024}, el resultado es...
 ### Tutoriales recomendados
 
 | Recurso | Idioma | Descripción |
-|---------|--------|-------------|
+| --------- | -------- | ------------- |
 | [Overleaf Learn](https://www.overleaf.com/learn) | EN/ES | Tutorial completo y ejemplos |
 | [LaTeX en 30 minutos](https://www.overleaf.com/learn/latex/Learn_LaTeX_in_30_minutes) | EN | Introducción rápida |
 | [LaTeX Project](https://www.latex-project.org/help/documentation/) | EN | Documentación oficial |
@@ -474,7 +475,7 @@ Según García \cite{garcia2024}, el resultado es...
 ### Herramientas útiles
 
 | Herramienta | Para qué sirve |
-|-------------|----------------|
+| ------------- | ---------------- |
 | [Overleaf Learn](https://www.overleaf.com/learn) | Documentación excelente (aunque uses editor local) |
 | [Detexify](https://detexify.kirelabs.org/) | Dibuja un símbolo y te dice el comando |
 | [Tables Generator](https://www.tablesgenerator.com/) | Crea tablas visualmente |
@@ -493,7 +494,7 @@ Si utilizas herramientas como ChatGPT, Claude o GitHub Copilot para redactar o s
 El proyecto incluye agentes preconfigurados para las tareas más comunes:
 
 | Tarea | GitHub Copilot | Claude |
-|-------|---------------|--------|
+| ------- | --------------- | -------- |
 | Instalar el entorno | [instalacion.md](../.github/agents/instalacion.md) | [instalacion-claude.md](agents/instalacion-claude.md) |
 | Redactar capítulos | [redaccion.md](../.github/agents/redaccion.md) | [redaccion-claude.md](agents/redaccion-claude.md) |
 | Revisar antes de la defensa | [revisor.md](../.github/agents/revisor.md) | [revisor-claude.md](agents/revisor-claude.md) |

--- a/docs/IMAGENES_SUBFIGURAS.md
+++ b/docs/IMAGENES_SUBFIGURAS.md
@@ -86,7 +86,7 @@ Esta plantilla utiliza los siguientes paquetes para manejo de imágenes:
 Con LuaLaTeX (usado por esta plantilla) puedes incluir:
 
 | Formato | Extensión | Notas |
-|---------|-----------|-------|
+| --------- | ----------- | ------- |
 | PDF | `.pdf` | **Recomendado** para diagramas vectoriales |
 | PNG | `.png` | Bueno para capturas, diagramas |
 | JPG/JPEG | `.jpg`, `.jpeg` | Bueno para fotografías |
@@ -151,7 +151,7 @@ recursos/
 ### Todas las opciones disponibles
 
 | Opción | Descripción | Ejemplo |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `width` | Ancho de la imagen | `5cm`, `0.8\textwidth` |
 | `height` | Alto de la imagen | `4cm`, `0.5\textheight` |
 | `scale` | Escala proporcional | `0.5`, `1.2` |
@@ -277,7 +277,7 @@ La \autoref{fig:mi-figura} ilustra el proceso.
 ### Opciones de captionsetup
 
 | Opción | Descripción | Valores |
-|--------|-------------|---------|
+| -------- | ------------- | --------- |
 | `font` | Fuente del texto | `small`, `footnotesize`, `sf` |
 | `labelfont` | Fuente de etiqueta | `bf`, `it`, `sf`, `sc` |
 | `textfont` | Fuente del texto | `it`, `sl`, `sf` |
@@ -469,7 +469,7 @@ Ver Figuras~\ref{fig:antes} y \ref{fig:despues}.
 ### Especificadores de posición
 
 | Especificador | Significado |
-|--------------|-------------|
+| -------------- | ------------- |
 | `h` | Here - Aquí, si hay espacio |
 | `t` | Top - Arriba de la página |
 | `b` | Bottom - Abajo de la página |
@@ -605,7 +605,7 @@ una vez que pase la imagen.
 ### Opciones de wrapfigure
 
 | Posición | Significado |
-|----------|-------------|
+| ---------- | ------------- |
 | `r` / `R` | Derecha |
 | `l` / `L` | Izquierda |
 | `i` / `I` | Interior (encuadernación) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ Bienvenido a la documentación detallada de la plantilla TFG/TFM EPS Universidad
 Ver el **[índice completo de agentes](agents/README.md)** para instrucciones de uso.
 
 | Agente | Copilot | Claude | Prompts |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Instalación guiada | [instalacion.md](../.github/agents/instalacion.md) | [instalacion-claude.md](agents/instalacion-claude.md) | [prompts-instalacion.md](agents/prompts-instalacion.md) |
 | Redacción de capítulos | [redaccion.md](../.github/agents/redaccion.md) | [redaccion-claude.md](agents/redaccion-claude.md) | [prompts-redaccion.md](agents/prompts-redaccion.md) |
 | Revisor tipo tribunal | [revisor.md](../.github/agents/revisor.md) | [revisor-claude.md](agents/revisor-claude.md) | [prompts-revisor.md](agents/prompts-revisor.md) |

--- a/docs/REFERENCIAS_CRUZADAS.md
+++ b/docs/REFERENCIAS_CRUZADAS.md
@@ -317,7 +317,7 @@ En particular, la Figura~\ref{fig:sub_a} presenta...
 ### Opciones principales
 
 | Opción | Descripción |
-|--------|-------------|
+| -------- | ------------- |
 | `colorlinks` | Enlaces en color (sin recuadro) |
 | `linkcolor` | Color de enlaces internos |
 | `citecolor` | Color de citas bibliográficas |
@@ -473,7 +473,7 @@ La \figref{fig:diagrama} muestra...
 ### Convención de nombres para etiquetas
 
 | Prefijo | Uso | Ejemplo |
-|---------|-----|---------|
+| --------- | ----- | --------- |
 | `cap:` | Capítulos | `\label{cap:introduccion}` |
 | `sec:` | Secciones | `\label{sec:metodologia}` |
 | `subsec:` | Subsecciones | `\label{subsec:datos}` |

--- a/docs/TABLAS.md
+++ b/docs/TABLAS.md
@@ -111,7 +111,7 @@ La plantilla define estos tipos de columna adicionales:
 ### Especificadores de columna básicos
 
 | Especificador | Alineación |
-|---------------|------------|
+| --------------- | ------------ |
 | `l` | Izquierda |
 | `c` | Centro |
 | `r` | Derecha |
@@ -156,7 +156,7 @@ El paquete `booktabs` proporciona líneas horizontales más elegantes. **Regla d
 ### Comandos de booktabs
 
 | Comando | Uso |
-|---------|-----|
+| --------- | ----- |
 | `\toprule` | Línea superior (gruesa) |
 | `\midrule` | Línea media (normal) |
 | `\bottomrule` | Línea inferior (gruesa) |
@@ -339,7 +339,7 @@ El paquete `booktabs` proporciona líneas horizontales más elegantes. **Regla d
 ### Especificador X
 
 | Tipo | Comportamiento |
-|------|----------------|
+| ------ | ---------------- |
 | `X` | Expansión automática, justificado |
 | `>{\raggedright\arraybackslash}X` | Expansión, alineado izquierda |
 | `>{\centering\arraybackslash}X` | Expansión, centrado |
@@ -434,7 +434,7 @@ Para tablas que ocupan múltiples páginas:
 ### Estructura de longtable
 
 | Comando | Uso |
-|---------|-----|
+| --------- | ----- |
 | `\endfirsthead` | Fin de cabecera primera página |
 | `\endhead` | Fin de cabecera páginas siguientes |
 | `\endfoot` | Fin de pie páginas intermedias |
@@ -982,7 +982,7 @@ donde observamos que...
 ### Documentación oficial
 
 | Paquete | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [booktabs](https://ctan.org/pkg/booktabs) | Líneas profesionales para tablas |
 | [longtable](https://ctan.org/pkg/longtable) | Tablas multipágina |
 | [tabularx](https://ctan.org/pkg/tabularx) | Ancho automático de columnas |

--- a/docs/TEXTO_LISTAS.md
+++ b/docs/TEXTO_LISTAS.md
@@ -78,7 +78,7 @@ Esta guía explica todas las opciones de formato de texto, listas, y estructurac
 ### Estilos de texto
 
 | Comando | Resultado | Descripción |
-|---------|-----------|-------------|
+| --------- | ----------- | ------------- |
 | `\textbf{texto}` | **texto** | Negrita |
 | `\textit{texto}` | *texto* | Cursiva |
 | `\underline{texto}` | <u>texto</u> | Subrayado |
@@ -884,7 +884,7 @@ Los caracteres especiales % $ & _ también.
 ### Caracteres reservados en LaTeX
 
 | Carácter | Cómo escribirlo |
-|----------|-----------------|
+| ---------- | ----------------- |
 | `#` | `\#` |
 | `$` | `\$` |
 | `%` | `\%` |

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -14,7 +14,7 @@ Guía a un estudiante sin experiencia para instalar y configurar el entorno
 completo (LaTeX, Python, latexminted, make) en Windows, macOS o Linux.
 
 | Archivo | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [../../.github/agents/instalacion.md](../../.github/agents/instalacion.md) | Versión para GitHub Copilot |
 | [instalacion-claude.md](instalacion-claude.md) | Versión para Claude |
 | [prompts-instalacion.md](prompts-instalacion.md) | Prompts listos (I01–I08) |
@@ -27,7 +27,7 @@ Ayuda a redactar secciones y capítulos completos en LaTeX respetando las
 convenciones de la plantilla EPS UA.
 
 | Archivo | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [../../.github/agents/redaccion.md](../../.github/agents/redaccion.md) | Versión para GitHub Copilot |
 | [redaccion-claude.md](redaccion-claude.md) | Versión para Claude |
 | [prompts-redaccion.md](prompts-redaccion.md) | Prompts listos |
@@ -40,7 +40,7 @@ Evalúa el documento completo en 8 dimensiones antes de la defensa y genera
 un informe estructurado de mejora.
 
 | Archivo | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | [../../.github/agents/revisor.md](../../.github/agents/revisor.md) | Versión para GitHub Copilot |
 | [revisor-claude.md](revisor-claude.md) | Versión para Claude |
 | [prompts-revisor.md](prompts-revisor.md) | Prompts listos |

--- a/docs/agents/instalacion-claude.md
+++ b/docs/agents/instalacion-claude.md
@@ -41,7 +41,7 @@ Cuando ayudes con la instalación de esta plantilla, ten en cuenta:
 ### Dependencias obligatorias
 
 | Herramienta | Para qué sirve | Forma de verificar |
-|---|---|---|
+| --- | --- | --- |
 | Python 3.8+ | Ejecutar scripts y minted | `python3 --version` |
 | pip | Instalar paquetes Python | `pip --version` |
 | latexminted | Resaltado de código en PDF | `pip show latexminted` |
@@ -84,7 +84,7 @@ lualatex -shell-escape -interaction=nonstopmode main.tex
 ### Tabla de errores frecuentes
 
 | Mensaje de error | Causa | Solución |
-|---|---|---|
+| --- | --- | --- |
 | `command not found: lualatex` | LaTeX no instalado o no en PATH | Instalar TeX Live / MiKTeX |
 | `You must invoke LaTeX with -shell-escape` | Falta el flag | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` / `latexminted not found` | Paquete Python no instalado | `pip install latexminted` |

--- a/docs/agents/redaccion-claude.md
+++ b/docs/agents/redaccion-claude.md
@@ -9,7 +9,7 @@ Universidad de Alicante (UA). Versión de plantilla: 2.1.0 (2026).
 ## Contexto técnico
 
 | Parámetro | Valor |
-|---|---|
+| --- | --- |
 | Motor | LuaLaTeX (nunca pdfLaTeX ni XeLaTeX) |
 | Clase | `cls/eps-tfg.cls` (KOMA-Script `scrbook`) |
 | Bibliografía | BibLaTeX + Biber, estilo APA 7 |
@@ -53,7 +53,7 @@ Contenido de la subsección.
 ### Prefijos de etiquetas (obligatorios)
 
 | Prefijo | Elemento |
-|---|---|
+| --- | --- |
 | `chap:` | Capítulo |
 | `sec:` | Sección / subsección |
 | `fig:` | Figura |

--- a/docs/agents/revisor-claude.md
+++ b/docs/agents/revisor-claude.md
@@ -22,7 +22,7 @@ y áreas de mejora antes de la defensa.
 ## Contexto técnico de la plantilla
 
 | Parámetro | Valor |
-|---|---|
+| --- | --- |
 | Motor | LuaLaTeX |
 | Clase | `cls/eps-tfg.cls` (KOMA-Script `scrbook`) |
 | Bibliografía | BibLaTeX + Biber, estilo APA 7 |
@@ -116,7 +116,7 @@ de los datos \parencite{lecun2015}.
 **Ejemplos de corrección:**
 
 | Incorrecto | Correcto |
-|---|---|
+| --- | --- |
 | "Yo he desarrollado una aplicación" | "En este trabajo se ha desarrollado una aplicación" |
 | "Mi sistema funciona muy bien" | "El sistema propuesto obtiene resultados satisfactorios" |
 | "Creo que los resultados son buenos" | "Los resultados obtenidos muestran que..." |
@@ -287,7 +287,7 @@ de si el trabajo está listo para defender o necesita revisión.]
 ## Criterios de severidad
 
 | Severidad | Criterio | Ejemplos |
-|---|---|---|
+| --- | --- | --- |
 | **Crítico** | Puede causar suspenso o correcciones mayores | Objetivos no cumplidos, plagio evidente, falta de capítulos obligatorios |
 | **Importante** | Resta calidad significativamente | Bibliografía desactualizada, incoherencias entre capítulos, tablas sin booktabs |
 | **Menor** | Detalles de presentación | Párrafos demasiado cortos, acrónimos sin definir en algún caso aislado |

--- a/recursos/figuras/README.md
+++ b/recursos/figuras/README.md
@@ -5,7 +5,7 @@ Esta carpeta está destinada a almacenar todas las imágenes y gráficos del doc
 ## 📋 Formatos Recomendados
 
 | Formato | Uso Recomendado | Ventajas |
-|---------|-----------------|----------|
+| --------- | ----------------- | ---------- |
 | **PDF** | Gráficos vectoriales, diagramas | Escalable sin pérdida de calidad |
 | **PNG** | Capturas de pantalla, interfaces | Buena calidad, soporta transparencia |
 | **JPG** | Fotografías | Menor tamaño de archivo |

--- a/sty/README.md
+++ b/sty/README.md
@@ -9,7 +9,7 @@ Esta carpeta contiene los paquetes auxiliares de la plantilla.
 ## 📁 Archivos
 
 | Archivo | Descripción |
-|---------|-------------|
+| --------- | ------------- |
 | `eps-portadas.sty` | Genera las portadas oficiales (color y B/N) |
 | `eps-codigo.sty` | Estilos de código fuente tipo VS Code |
 
@@ -26,7 +26,7 @@ Genera las portadas oficiales del TFG/TFM usando TikZ para el diseño gráfico.
 #### Tecnologías
 
 | Paquete | Uso |
-|---------|-----|
+| --------- | ----- |
 | **tikz** | Dibujo de fondos, franjas y posicionamiento de logos |
 | **tikzpagenodes** | Referencia a coordenadas de la página |
 | **textpos** | Posicionamiento absoluto de bloques de texto |
@@ -113,7 +113,7 @@ Define estilos para bloques de código fuente que imitan la apariencia de VS Cod
 #### Tecnologías
 
 | Paquete | Uso |
-|---------|-----|
+| --------- | ----- |
 | **minted** | Resaltado de sintaxis con latexminted/Pygments |
 | **tcolorbox** | Cajas con estilo (bordes redondeados, títulos) |
 | **fontawesome5** | Iconos para los títulos de los bloques |
@@ -157,7 +157,7 @@ eps-codigo.sty
 #### Entornos de código disponibles
 
 | Entorno | Lenguaje | Con líneas | Sin líneas |
-|---------|----------|------------|------------|
+| --------- | ---------- | ------------ | ------------ |
 | Python | python | `pythoncode` | `pythoncode*` |
 | Java | java | `javacode` | `javacode*` |
 | C++ | cpp | `cppcode` | `cppcode*` |
@@ -248,7 +248,7 @@ Cambiar los estilos base para usar `vscode-dark-*` en lugar de `vscode-light-*`.
 ## 🔗 Archivos relacionados
 
 | Archivo | Relación |
-|---------|----------|
+| --------- | ---------- |
 | `cls/eps-tfg.cls` | Clase principal que carga estos paquetes |
 | `recursos/logos/` | Logos usados por eps-portadas.sty |
 | `docs/CODIGO_FUENTE.md` | Documentación para usuarios |


### PR DESCRIPTION
## Resumen

- **MD036**: Elimina `**negrita**` usada como subtítulo en README.md
- **MD045**: Añade `alt=` a todas las imágenes de portadas en README.md (accesibilidad)
- **MD051**: Corrige 15 anclas rotas en CONTRIBUTING.md, docs/AI_CONTEXT.md, docs/COMPONENTES.md y docs/GUIA_PRINCIPIANTES.md (emojis con variante selector, ⭐ mid-text, caracteres especiales)
- **MD060**: Normaliza separadores de tabla `|---|` → `| --- |` en 29 archivos
- **Config**: Actualiza `.markdownlint.json` activando las 4 reglas; mantiene MD013, MD033 y MD041 deshabilitadas (justificadas)

## Plan de test

- [ ] Ejecutar `npx markdownlint-cli2 "**/*.md"` → debe devolver 0 errores
- [ ] Verificar que los enlaces de los TOC siguen funcionando en GitHub
- [ ] Revisar visualmente el README.md (imágenes de portadas con alt text)

## Summary by Sourcery

Align documentation Markdown files with newly enabled markdownlint rules and improve accessibility metadata.

Documentation:
- Normalize table formatting and heading/link anchors across documentation to satisfy markdownlint style and anchor rules.
- Add alternative text to README cover images and adjust headings to avoid bold-only titles, improving accessibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved Markdown table formatting consistency across many docs for clearer rendering.
  * Enhanced image accessibility by adding alt text descriptions in README and examples.
  * Normalized headings and table-of-contents anchors for consistent navigation.

* **Style**
  * Restored several Markdown lint rules to default (removed explicit overrides).
  * Adjusted heading/emoji spacing and other minor heading formatting for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->