### PR TITLE
Actualiza dependencias de CI y añade badge awesome

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build LaTeX Document
 
 # Run name dinámico para mejor visibilidad en la UI
 run-name: >-
-  ${{ github.event_name == 'pull_request' 
-      && format('PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title) 
+  ${{ github.event_name == 'pull_request'
+      && format('PR #{0}: {1}', github.event.pull_request.number, github.event.pull_request.title)
       || format('Build: {0}', github.event.head_commit.message || 'Manual trigger') }}
 
 on:
@@ -52,44 +52,44 @@ jobs:
     if: github.event_name == 'pull_request'
     outputs:
       comment_id: ${{ steps.create-comment.outputs.comment_id }}
-    
+
     steps:
     - name: Create or update initial comment
       id: create-comment
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
           const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const sha = context.payload.pull_request.head.sha.substring(0, 7);
-          
+
           const body = `## 📄 Compilación del documento
-          
+
           ⏳ **Compilando...** El documento se está procesando.
-          
+
           | Detalle | Valor |
           |---------|-------|
           | **Commit** | \`${sha}\` |
           | **Estado** | 🔄 En progreso |
-          
+
           👉 **[Ver progreso del workflow](${runUrl})**
-          
+
           ---
           *Generado automáticamente por GitHub Actions* 🤖
           `;
-          
+
           // Buscar comentario existente del bot
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
           });
-          
-          const botComment = comments.find(comment => 
-            comment.user.type === 'Bot' && 
+
+          const botComment = comments.find(comment =>
+            comment.user.type === 'Bot' &&
             comment.body.includes('📄 Compilación del documento')
           );
-          
+
           let commentId;
           if (botComment) {
             await github.rest.issues.updateComment({
@@ -108,7 +108,7 @@ jobs:
             });
             commentId = newComment.id;
           }
-          
+
           core.setOutput('comment_id', commentId);
 
   # 2. Compilar documento
@@ -118,11 +118,11 @@ jobs:
     timeout-minutes: 30
     # No depender de init-comment para que push y workflow_dispatch funcionen
     if: "!cancelled()"
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-      
+
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v4
       with:
@@ -139,7 +139,7 @@ jobs:
           sed -i 's/\\input{eps-metadata}/%\\input{eps-metadata}/' main.tex
           echo "Verificando que eps-metadata está comentado:"
           grep -n "eps-metadata" main.tex
-        
+
     - name: Upload PDF artifact
       uses: actions/upload-artifact@v7
       with:
@@ -163,10 +163,10 @@ jobs:
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request' && !cancelled()
     needs: [init-comment, build]
-    
-    steps:       
+
+    steps:
     - name: Update PR comment with result
-      uses: actions/github-script@v8
+      uses: actions/github-script@v9
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         script: |
@@ -174,59 +174,59 @@ jobs:
           const runUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
           const prNumber = context.issue.number;
           const sha = context.payload.pull_request.head.sha.substring(0, 7);
-          
+
           const isSuccess = buildResult === 'success';
           const statusEmoji = isSuccess ? '✅' : '❌';
           const statusText = isSuccess ? 'Compilado correctamente' : 'Error de compilación';
-          
+
           let body = `## 📄 Compilación del documento
-          
+
           ${statusEmoji} **${statusText}**
-          
+
           | Detalle | Valor |
           |---------|-------|
           | **Commit** | \`${sha}\` |
           | **PR** | #${prNumber} |
           | **TeX Live** | ${{ env.TEXLIVE_VERSION }} |
           `;
-          
+
           if (isSuccess) {
             body += `
           ### 📥 Descargar PDF
-          
+
           👉 **[Ver workflow y descargar artefactos](${runUrl})**
-          
+
           En la sección "Artifacts" encontrarás el archivo **TFG-TFM_EPS_UA** con el PDF compilado.
-          
+
           > **Nota:** Los artefactos estarán disponibles durante 90 días.
           `;
           } else {
             body += `
           ### ⚠️ Error en la compilación
-          
+
           👉 **[Ver logs del workflow](${runUrl})**
-          
+
           Revisa los logs para identificar el problema.
           `;
           }
-          
+
           body += `
           ---
           *Generado automáticamente por GitHub Actions* 🤖
           `;
-          
+
           // Buscar y actualizar el comentario del bot
           const { data: comments } = await github.rest.issues.listComments({
             owner: context.repo.owner,
             repo: context.repo.repo,
             issue_number: context.issue.number,
           });
-          
-          const botComment = comments.find(comment => 
-            comment.user.type === 'Bot' && 
+
+          const botComment = comments.find(comment =>
+            comment.user.type === 'Bot' &&
             comment.body.includes('📄 Compilación del documento')
           );
-          
+
           if (botComment) {
             await github.rest.issues.updateComment({
               owner: context.repo.owner,
@@ -249,14 +249,14 @@ jobs:
     runs-on: ubuntu-latest
     # Solo ejecutar en workflow_dispatch, PR, o push (el workflow ya tiene path filters)
     if: >-
-      github.event_name == 'workflow_dispatch' || 
+      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request' ||
       github.event_name == 'push'
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
-      
+
     - name: Check README links
       uses: gaurav-nelson/github-action-markdown-link-check@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,13 +24,13 @@ jobs:
     name: Crear release
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
-      
+
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v4
       with:
@@ -44,10 +44,10 @@ jobs:
           # Deshabilitar DocumentMetadata en CI (pdfstandard=ua-2 carga el paquete
           # 'block' experimental que es incompatible con opciones de enumitem).
           sed -i 's/\\input{eps-metadata}/%\\input{eps-metadata}/' main.tex
-        
+
     - name: Rename PDF
       run: mv main.pdf TFG-TFM_EPS_UA.pdf
-      
+
     - name: Get version
       id: version
       run: |
@@ -56,51 +56,51 @@ jobs:
         else
           echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
         fi
-        
+
     - name: Generate release notes
       id: notes
       run: |
         VERSION="${{ steps.version.outputs.VERSION }}"
         cat << EOF > release_notes.md
         ## 📦 Plantilla TFG/TFM - EPS Universidad de Alicante
-        
+
         Esta release **${VERSION}** incluye la plantilla LaTeX actualizada y el documento de ejemplo compilado.
-        
+
         ### 📥 Archivos incluidos
-        
+
         - **TFG-TFM_EPS_UA.pdf** - Documento de ejemplo compilado
         - **Source code** - Código fuente de la plantilla
-        
+
         ### 🚀 Cómo usar
-        
+
         1. Descarga el código fuente (zip o tar.gz)
         2. Extrae los archivos
         3. Abre el proyecto en tu editor LaTeX favorito
         4. Compila con **LuaLaTeX** usando el flag \`-shell-escape\`
-        
+
         ### 📋 Requisitos
-        
+
         - TeX Live ${{ env.TEXLIVE_VERSION }} o superior
         - LuaLaTeX (obligatorio)
         - latexminted para resaltado de código (\`pip install latexminted\`)
-        
+
         ### 📖 Documentación
-        
+
         Consulta la carpeta \`docs/\` para guías detalladas sobre:
         - Ecuaciones matemáticas
         - Tablas y figuras
         - Código fuente
         - Bibliografía
         - Glosarios y acrónimos
-        
+
         ---
         *Escuela Politécnica Superior - Universidad de Alicante*
-        
+
         > Compilado automáticamente con GitHub Actions 🤖
         EOF
-        
+
     - name: Create Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         tag_name: ${{ steps.version.outputs.VERSION }}
         name: Release ${{ steps.version.outputs.VERSION }}

--- a/.github/workflows/revision.yml
+++ b/.github/workflows/revision.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configurar Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -53,7 +53,7 @@ jobs:
       - name: Comentar en PR con resumen
         if: github.event_name == 'pull_request' && steps.revision.outputs.informe_existe == 'true'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Universidad de Alicante
 [![LaTeX](https://img.shields.io/badge/LaTeX-LuaLaTeX-008080?logo=latex)](https://www.latex-project.org/)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Version](https://img.shields.io/badge/Versión-2.1.0-blue.svg)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
+[![listed on awesome-comunitat-valenciana](https://img.shields.io/badge/listed%20on-awesome--comunitat--valenciana-FFB81C?style=flat&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCI+PGcgZmlsbD0iI0ZGQjgxQyI+PHJlY3QgeD0iNiIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjQiIHk9IjQiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI4IiB5PSI0IiB3aWR0aD0iMiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iMiIgeT0iMyIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjEwIiB5PSIzIiB3aWR0aD0iMiIgaGVpZ2h0PSI0Ii8+PHJlY3QgeD0iMCIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iMyIvPjxyZWN0IHg9IjEyIiB5PSIyIiB3aWR0aD0iMiIgaGVpZ2h0PSIzIi8+PHJlY3QgeD0iNSIgeT0iOCIgd2lkdGg9IjQiIGhlaWdodD0iMiIvPjxyZWN0IHg9IjQiIHk9IjEwIiB3aWR0aD0iNiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iNSIgeT0iMTIiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI3IiB5PSIxMiIgd2lkdGg9IjIiIGhlaWdodD0iMiIvPjwvZz48L3N2Zz4=&labelColor=0056A0)](https://github.com/GeiserX/awesome-comunitat-valenciana#readme)
 
 Plantilla LaTeX moderna y profesional para la elaboración de **Trabajos de Fin de Grado (TFG)** y **Trabajos de Fin de Máster (TFM)** de la Escuela Politécnica Superior de la Universidad de Alicante.
 


### PR DESCRIPTION
Actualiza las versiones de GitHub Actions propuestas por Dependabot y añade al README la insignia por defecto de awesome-comunitat-valenciana.

Cambios principales:
- Actualiza `actions/github-script` a v9.
- Actualiza `actions/checkout` a v6 y `actions/setup-python` a v6 en la revisión estática.
- Actualiza `softprops/action-gh-release` a v3.
- Añade el badge `listed on awesome-comunitat-valenciana` al README.

Relacionado con #22.

## Summary by Sourcery

Update CI workflows to use newer GitHub Actions versions and refresh project metadata.

Enhancements:
- Upgrade actions/github-script to v9 across build and revision workflows.
- Update actions/checkout to v6 and actions/setup-python to v6 in CI workflows.
- Bump softprops/action-gh-release to v3 for release publishing.
- Add an awesome-comunitat-valenciana listing badge to the README badges section.

Build:
- Keep CI workflows in sync with current action versions for build, release, and revision pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added community recognition badge to the project README.

* **Chores**
  * Updated GitHub Actions workflow dependencies to their latest versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jmrplens/TFG-TFM_EPS/pull/27)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->