### PR TITLE
ci: add auto-assign workflow

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,22 @@
+name: Auto-assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Assign to jmrplens
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
+        run: |
+          gh api             --method POST             -H "Accept: application/vnd.github+json"             /repos/$REPO/issues/$NUMBER/assignees             -f assignees[]=jmrplens


### PR DESCRIPTION
Auto-assigns newly opened issues and PRs to @jmrplens.

Uses `gh api` with `GITHUB_TOKEN`, no external dependencies.

## Summary by Sourcery

CI:
- Introduce an auto-assign workflow that uses GitHub CLI and repository token to assign new issues and pull requests to @jmrplens.