### PR TITLE
ci: skip self-assignment

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -12,6 +12,9 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+    if: >-
+      (github.event_name == 'issues' && github.event.issue.user.login != 'jmrplens') ||
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login != 'jmrplens')
     steps:
       - name: Assign to jmrplens
         env:
@@ -19,4 +22,8 @@ jobs:
           REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number || github.event.pull_request.number }}
         run: |
-          gh api             --method POST             -H "Accept: application/vnd.github+json"             /repos/$REPO/issues/$NUMBER/assignees             -f assignees[]=jmrplens
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            /repos/$REPO/issues/$NUMBER/assignees \
+            -f assignees[]=jmrplens


### PR DESCRIPTION
El workflow ahora no asigna si el autor es @jmrplens.

## Summary by Sourcery

CI:
- Add conditional execution to the auto-assign workflow so it skips items created by jmrplens.