### PR TITLE
feat: DOI de Zenodo, bump a 2.2.1 y actualización de actions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Instrucciones para GitHub Copilot — Plantilla TFG/TFM EPS UA
 
 Plantilla LaTeX para TFG/TFM de la Escuela Politécnica Superior (EPS),
-Universidad de Alicante. Versión 2.1.0 (2026).
+Universidad de Alicante. Versión 2.2.1 (2026).
 
 ---
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Compile LaTeX document
       uses: xu-cheng/latex-action@v4
@@ -255,7 +255,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
 
     - name: Check README links
       uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         fetch-depth: 0
 

--- a/.github/workflows/revision.yml
+++ b/.github/workflows/revision.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Configurar Python
         uses: actions/setup-python@v6

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ opere sobre este repositorio.
 Plantilla LaTeX para Trabajos de Fin de Grado (TFG) y Máster (TFM) de la
 Escuela Politécnica Superior (EPS) de la Universidad de Alicante (UA).
 
-- **Versión:** 2.1.0 (2026)
+- **Versión:** 2.2.1 (2026)
 - **Motor de compilación:** LuaLaTeX (obligatorio, nunca pdfLaTeX)
 - **Clase principal:** `cls/eps-tfg.cls` (basada en KOMA-Script `scrbook`)
 - **Bibliografía:** BibLaTeX + Biber, estilo APA 7

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,9 @@ cff-version: 1.2.0
 message: "Si utilizas esta plantilla, por favor cítala como se indica a continuación."
 type: software
 title: "Plantilla LaTeX TFG/TFM — Escuela Politécnica Superior (Universidad de Alicante)"
-version: 2.2.0
-date-released: 2026-04-09
+version: 2.2.1
+date-released: 2026-07-11
+doi: "10.5281/zenodo.21315904"
 authors:
   - family-names: "Requena Plens"
     given-names: "José Manuel"
@@ -21,5 +22,3 @@ keywords:
   - thesis
   - Universidad de Alicante
   - Escuela Politécnica Superior
-# Tras la primera release en Zenodo, añade aquí el DOI de concepto ("all versions"):
-# doi: "10.5281/zenodo.XXXXXXXX"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Instrucciones para Claude
 
 Plantilla LaTeX para TFG/TFM de la Escuela Politécnica Superior (EPS),
-Universidad de Alicante. Versión 2.1.0 (2026).
+Universidad de Alicante. Versión 2.2.1 (2026).
 
 Motor: **LuaLaTeX** (obligatorio). Bibliografía: **BibLaTeX + Biber** (APA 7).
 Código: **minted 3.x** con `latexminted`.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Universidad de Alicante
 
 [![LaTeX](https://img.shields.io/badge/LaTeX-LuaLaTeX-008080?logo=latex)](https://www.latex-project.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Versión-2.1.0-blue.svg)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
-[![DOI](https://img.shields.io/badge/DOI-pendiente-lightgrey?logo=doi&logoColor=white)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
+[![Version](https://img.shields.io/badge/Versión-2.2.1-blue.svg)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21315904-blue?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.21315904)
 [![listed on awesome-comunitat-valenciana](https://img.shields.io/badge/listed%20on-awesome--comunitat--valenciana-FFB81C?style=flat&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCI+PGcgZmlsbD0iI0ZGQjgxQyI+PHJlY3QgeD0iNiIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjQiIHk9IjQiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI4IiB5PSI0IiB3aWR0aD0iMiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iMiIgeT0iMyIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjEwIiB5PSIzIiB3aWR0aD0iMiIgaGVpZ2h0PSI0Ii8+PHJlY3QgeD0iMCIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iMyIvPjxyZWN0IHg9IjEyIiB5PSIyIiB3aWR0aD0iMiIgaGVpZ2h0PSIzIi8+PHJlY3QgeD0iNSIgeT0iOCIgd2lkdGg9IjQiIGhlaWdodD0iMiIvPjxyZWN0IHg9IjQiIHk9IjEwIiB3aWR0aD0iNiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iNSIgeT0iMTIiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI3IiB5PSIxMiIgd2lkdGg9IjIiIGhlaWdodD0iMiIvPjwvZz48L3N2Zz4=&labelColor=0056A0)](https://github.com/GeiserX/awesome-comunitat-valenciana#readme)
 
 Plantilla LaTeX moderna y profesional para la elaboración de **Trabajos de Fin de Grado (TFG)** y **Trabajos de Fin de Máster (TFM)** de la Escuela Politécnica Superior de la Universidad de Alicante.

--- a/cls/eps-tfg.cls
+++ b/cls/eps-tfg.cls
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[2022/06/01]
-\ProvidesClass{eps-tfg}[2026/02/05 v2.1.0 Clase TFG/TFM EPS Universidad de Alicante]
+\ProvidesClass{eps-tfg}[2026/07/11 v2.2.1 Clase TFG/TFM EPS Universidad de Alicante]
 
 %% ============================================================================
 %% ARQUITECTURA DE LA CLASE

--- a/configuracion.tex
+++ b/configuracion.tex
@@ -4,7 +4,7 @@
 %%
 %% Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 %% Autor:    José Manuel Requena Plens
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %% =============================================================================
 %
 % Este archivo contiene toda la información personal y del trabajo.

--- a/docs/agents/redaccion-claude.md
+++ b/docs/agents/redaccion-claude.md
@@ -2,7 +2,7 @@
 
 Eres un experto en redacción académica en LaTeX para Trabajos de Fin de Grado
 (TFG) y Máster (TFM) de la Escuela Politécnica Superior (EPS) de la
-Universidad de Alicante (UA). Versión de plantilla: 2.1.0 (2026).
+Universidad de Alicante (UA). Versión de plantilla: 2.2.1 (2026).
 
 ---
 

--- a/docs/agents/revisor-claude.md
+++ b/docs/agents/revisor-claude.md
@@ -2,7 +2,7 @@
 
 Eres un tribunal académico experto en la evaluación de Trabajos de Fin de
 Grado (TFG) y Máster (TFM) de la Escuela Politécnica Superior (EPS) de la
-Universidad de Alicante (UA). Versión de plantilla: 2.1.0 (2026).
+Universidad de Alicante (UA). Versión de plantilla: 2.2.1 (2026).
 
 Tu misión es leer el documento del alumno y producir un informe de revisión
 estructurado, riguroso y constructivo, identificando problemas, inconsistencias

--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,7 @@
 %%
 %% Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 %% Autor:    José Manuel Requena Plens
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %% =============================================================================
 %
 % Este es el archivo principal del documento.

--- a/sty/componentes/eps-arquitectura.sty
+++ b/sty/componentes/eps-arquitectura.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-arquitectura.sty}[2026/02/05 v2.1.0 Componentes arquitectura EPS UA]
+\ProvidesFile{eps-arquitectura.sty}[2026/07/11 v2.2.1 Componentes arquitectura EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-comunes.sty
+++ b/sty/componentes/eps-comunes.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-comunes.sty}[2026/02/05 v2.1.0 Componentes comunes EPS UA]
+\ProvidesFile{eps-comunes.sty}[2026/07/11 v2.2.1 Componentes comunes EPS UA]
 
 % ============================================================================
 % CAJAS DE INFORMACIÓN

--- a/sty/componentes/eps-geologia.sty
+++ b/sty/componentes/eps-geologia.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-geologia.sty}[2026/02/05 v2.1.0 Componentes geología EPS UA]
+\ProvidesFile{eps-geologia.sty}[2026/07/11 v2.2.1 Componentes geología EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-prevencion.sty
+++ b/sty/componentes/eps-prevencion.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-prevencion.sty}[2026/02/05 v2.1.0 Componentes prevención EPS UA]
+\ProvidesFile{eps-prevencion.sty}[2026/07/11 v2.2.1 Componentes prevención EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-quimica.sty
+++ b/sty/componentes/eps-quimica.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-quimica.sty}[2026/02/05 v2.1.0 Componentes química EPS UA]
+\ProvidesFile{eps-quimica.sty}[2026/07/11 v2.2.1 Componentes química EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-software.sty
+++ b/sty/componentes/eps-software.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-software.sty}[2026/02/05 v2.1.0 Componentes software EPS UA]
+\ProvidesFile{eps-software.sty}[2026/07/11 v2.2.1 Componentes software EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-telecom.sty
+++ b/sty/componentes/eps-telecom.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-telecom.sty}[2026/02/05 v2.1.0 Componentes telecom EPS UA]
+\ProvidesFile{eps-telecom.sty}[2026/07/11 v2.2.1 Componentes telecom EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/eps-codigo.sty
+++ b/sty/eps-codigo.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{eps-codigo}[2026/02/05 v2.1.0 Estilos de código TFG/TFM EPS UA]
+\ProvidesPackage{eps-codigo}[2026/07/11 v2.2.1 Estilos de código TFG/TFM EPS UA]
 
 %% NOTA IMPORTANTE:
 %% Este paquete depende de 'minted', que a su vez requiere Python y Pygments instalado.

--- a/sty/eps-componentes.sty
+++ b/sty/eps-componentes.sty
@@ -5,7 +5,7 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% Uso:
 %%   \usepackage{eps-componentes}                    % Carga solo comunes
@@ -17,7 +17,7 @@
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{eps-componentes}[2026/02/05 v2.1.0 Componentes especializados EPS UA]
+\ProvidesPackage{eps-componentes}[2026/07/11 v2.2.1 Componentes especializados EPS UA]
 
 % ============================================================================
 % OPCIONES DEL PAQUETE (Modernizado con l3keys)

--- a/sty/eps-portadas.sty
+++ b/sty/eps-portadas.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.1.0 (2026/02/05)
+%% Versión:  2.2.1 (2026/07/11)
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{eps-portadas}[2026/02/05 v2.1.0 Portadas TFG/TFM EPS Universidad de Alicante]
+\ProvidesPackage{eps-portadas}[2026/07/11 v2.2.1 Portadas TFG/TFM EPS Universidad de Alicante]
 
 \RequirePackage{xparse}
 \RequirePackage{tikz}


### PR DESCRIPTION
## Resumen

Seguimiento de #32. La release **v2.2.1** disparó el webhook de Zenodo y se acuñó el DOI. Esta PR incorpora el DOI real, alinea la versión del árbol con el tag `v2.2.1` y actualiza la única GitHub Action desactualizada.

## Cambios

### 🔗 DOI (Zenodo)
- **`README.md`** — badge de DOI real (estilo Shields.io, como *phonometry*).
- **`CITATION.cff`** — campo `doi` con el **DOI de concepto** (`10.5281/zenodo.21315904`, "todas las versiones").

| | DOI |
|---|---|
| Concepto (todas las versiones) | [`10.5281/zenodo.21315904`](https://doi.org/10.5281/zenodo.21315904) |
| Versión v2.2.1 | `10.5281/zenodo.21315905` |

### 🔖 Bump de versión 2.1.0 → 2.2.1
Alinea el árbol con el tag `v2.2.1`. Afecta a: badge de versión del README, cabeceras y `\ProvidesXXX` de `.cls`/`.sty`, `main.tex`, `configuracion.tex`, `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`, `docs/agents/*`, y `CITATION.cff` (con fecha 2026-07-11).

**No se tocan:** `CHANGELOG.md` (histórico) ni los `\version{2.1.0}` que son ejemplos ilustrativos del componente (`marco-teorico.tex`, `docs/COMPONENTES.md`).

### ⚙️ GitHub Actions
- `actions/checkout@v6 → v7` en `build.yml` (×2), `release.yml`, `revision.yml`.

> Auditoría del resto de actions: `upload-artifact@v7`, `github-script@v9`, `setup-python@v6`, `latex-action@v4`, `action-gh-release@v3` y `markdown-link-check@v1` ya estaban en su última major.

https://claude.ai/code/session_017FNei3ZR5BDE1eTWpCDS9d

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/TFG-TFM_EPS/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated template and package version references to 2.2.1, dated July 11, 2026.
  * Refreshed the README version badge and added the published DOI.
  * Updated release citation metadata, including the release date and DOI.

* **Chores**
  * Updated automated workflows to use the latest repository checkout action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->