### PR TITLE
chore: consistencia total de versión (2.2.1) y licencia (MIT)

### DIFF
--- a/.herramientas/actualizar_previews.py
+++ b/.herramientas/actualizar_previews.py
@@ -9,7 +9,7 @@ Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 Autor:    José Manuel Requena Plens
 Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 Licencia: GNU GPL v3.0
-Versión:  2.1.0
+Versión:  2.2.1
 --------------------------------------------------------------------------------
 
 Este script:

--- a/.herramientas/actualizar_previews.py
+++ b/.herramientas/actualizar_previews.py
@@ -8,7 +8,7 @@ Herramienta unificada para generar e insertar previews de documentación LaTeX.
 Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 Autor:    José Manuel Requena Plens
 Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
-Licencia: GNU GPL v3.0
+Licencia: MIT
 Versión:  2.2.1
 --------------------------------------------------------------------------------
 
@@ -31,7 +31,7 @@ Uso:
     python3 actualizar_previews.py --limpiar       # Eliminar previews huérfanos
 
 Autor: Plantilla TFG/TFM EPS UA
-Licencia: GPL-3.0
+Licencia: MIT
 """
 
 import argparse

--- a/.herramientas/generar_portadas.py
+++ b/.herramientas/generar_portadas.py
@@ -9,7 +9,7 @@ Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 Autor:    José Manuel Requena Plens
 Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 Licencia: GNU GPL v3.0
-Versión:  2.1.0
+Versión:  2.2.1
 --------------------------------------------------------------------------------
 
 Este script:

--- a/.herramientas/generar_portadas.py
+++ b/.herramientas/generar_portadas.py
@@ -8,7 +8,7 @@ Generador automático de imágenes de portadas para el README.
 Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 Autor:    José Manuel Requena Plens
 Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
-Licencia: GNU GPL v3.0
+Licencia: MIT
 Versión:  2.2.1
 --------------------------------------------------------------------------------
 
@@ -19,7 +19,7 @@ Este script:
 4. Convierte a WebP y actualiza el README.md
 
 Autor: Plantilla TFG/TFM EPS UA
-Licencia: GPL-3.0
+Licencia: MIT
 """
 
 import os

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Autor:    José Manuel Requena Plens
 # Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 # Licencia: GNU GPL v3.0
-# Versión:  2.1.0
+# Versión:  2.2.1
 # ==============================================================================
 #
 # Comandos disponibles:

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 #
 # Autor:    José Manuel Requena Plens
 # Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
-# Licencia: GNU GPL v3.0
+# Licencia: MIT
 # Versión:  2.2.1
 # ==============================================================================
 #

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Plantilla LaTeX para Trabajos de Fin de Grado (TFG) y Máster (TFM) de la
 > Escuela Politécnica Superior (EPS) de la Universidad de Alicante.
-> Versión 2.1.0 (2026). Motor: LuaLaTeX. Bibliografía: BibLaTeX + Biber (APA 7).
+> Versión 2.2.1 (2026). Motor: LuaLaTeX. Bibliografía: BibLaTeX + Biber (APA 7).
 
 ## Instrucciones para agentes de IA
 

--- a/scripts/revision-rapida.py
+++ b/scripts/revision-rapida.py
@@ -563,7 +563,7 @@ def verificar_plagio_turnitin(texto: str, api_key: str, tenant_url: str) -> list
     base_headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Turnitin-Integration-Name": "TFG-TFM-EPS-UA",
-        "X-Turnitin-Integration-Version": "2.1.0",
+        "X-Turnitin-Integration-Version": "2.2.1",
     }
 
     def _request(method: str, path: str, body=None, binary: bool = False) -> dict:


### PR DESCRIPTION
## Resumen

Cierre de consistencia tras #32/#33: deja **todos** los marcadores de versión en `2.2.1` y **todas** las referencias de licencia en MIT, en los archivos fuera del árbol LaTeX que se habían quedado atrás.

## 1) Versión → 2.2.1 (5 marcadores)

| Archivo | Marcador |
|---|---|
| `llms.txt` | cabecera `Versión 2.2.1 (2026)` |
| `Makefile` | cabecera `# Versión: 2.2.1` |
| `.herramientas/generar_portadas.py` | cabecera `Versión: 2.2.1` |
| `.herramientas/actualizar_previews.py` | cabecera `Versión: 2.2.1` |
| `scripts/revision-rapida.py` | `X-Turnitin-Integration-Version: "2.2.1"` |

## 2) Licencia GPL → MIT (leftover de #32, que solo cubrió `.cls`/`.sty`)

- `Makefile` — cabecera.
- `.herramientas/generar_portadas.py` — cabecera + docstring.
- `.herramientas/actualizar_previews.py` — cabecera + docstring.

**Auditoría posterior: cero referencias GPL en todo el repo.** `LICENSE` ya contiene el texto de la licencia MIT (verificado).

## No tocado (a propósito)

- `.vscode/tasks.json` → `"version": "2.0.0"` es el schema de tasks.json.
- `pdfversion=2.0`, versiones de dependencias en `referencias.bib`, `python-version`, y los `\version{...}` que son ejemplos ilustrativos.

https://claude.ai/code/session_017FNei3ZR5BDE1eTWpCDS9d
