### PR TITLE
fix(overleaf): compatibilidad con LuaLaTeX en Overleaf y bump a 2.2.2

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Instrucciones para GitHub Copilot — Plantilla TFG/TFM EPS UA
 
 Plantilla LaTeX para TFG/TFM de la Escuela Politécnica Superior (EPS),
-Universidad de Alicante. Versión 2.2.1 (2026).
+Universidad de Alicante. Versión 2.2.2 (2026).
 
 ---
 
@@ -434,6 +434,7 @@ Pedir siempre las últimas 30 líneas de `main.log`.
 
 | Error | Solución |
 | --- | --- |
+| `TeX capacity exceeded [main memory size=5000000]` | Compilar con LuaLaTeX (Overleaf: Menu → Compiler → LuaLaTeX) |
 | `You must invoke LaTeX with -shell-escape` | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | `pip install latexminted` |
 | `Citation 'X' undefined` | Ejecutar `make` completo (biber) |

--- a/.herramientas/actualizar_previews.py
+++ b/.herramientas/actualizar_previews.py
@@ -9,7 +9,7 @@ Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 Autor:    José Manuel Requena Plens
 Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 Licencia: MIT
-Versión:  2.2.1
+Versión:  2.2.2
 --------------------------------------------------------------------------------
 
 Este script:

--- a/.herramientas/generar_portadas.py
+++ b/.herramientas/generar_portadas.py
@@ -9,7 +9,7 @@ Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 Autor:    José Manuel Requena Plens
 Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 Licencia: MIT
-Versión:  2.2.1
+Versión:  2.2.2
 --------------------------------------------------------------------------------
 
 Este script:

--- a/.latexmkrc
+++ b/.latexmkrc
@@ -19,6 +19,23 @@ $pdf_mode = 4;  # 4 = lualatex
 # Comando de LuaLaTeX con opciones necesarias
 $lualatex = 'lualatex -shell-escape -interaction=nonstopmode -file-line-error -synctex=1 %O %S';
 
+# ----------------------------------------------------------------------------
+# COMPATIBILIDAD CON OVERLEAF (y con `latexmk -pdf` / `-pdfxe` / `-pdfdvi`)
+# ----------------------------------------------------------------------------
+# Overleaf ignora la línea mágica «% !TeX program = lualatex» y elige el motor
+# desde Menu -> Compiler, pasándolo por línea de órdenes (-pdf, -pdfxe...).
+# Las opciones de la línea de órdenes tienen prioridad sobre $pdf_mode, así que
+# un proyecto importado a Overleaf compilaría con pdfLaTeX o XeLaTeX y fallaría
+# («TeX capacity exceeded», memoria fija de esos motores).
+#
+# Redirigimos esos motores a LuaLaTeX: así el proyecto compila en Overleaf
+# aunque el menú «Compiler» no esté en LuaLaTeX. latexmk detecta que la salida
+# es PDF en vez de XDV/DVI y ajusta la cadena automáticamente.
+# En la compilación normal (pdf_mode = 4) estas variables NO se usan.
+$pdflatex = 'lualatex -shell-escape -interaction=nonstopmode -file-line-error -synctex=1 %O %S';
+$xelatex  = 'lualatex -shell-escape -interaction=nonstopmode -file-line-error -synctex=1 %O %S';
+$latex    = 'lualatex -shell-escape -interaction=nonstopmode -file-line-error -synctex=1 %O %S';
+
 # Máximo número de iteraciones
 $max_repeat = 5;
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ opere sobre este repositorio.
 Plantilla LaTeX para Trabajos de Fin de Grado (TFG) y Máster (TFM) de la
 Escuela Politécnica Superior (EPS) de la Universidad de Alicante (UA).
 
-- **Versión:** 2.2.1 (2026)
+- **Versión:** 2.2.2 (2026)
 - **Motor de compilación:** LuaLaTeX (obligatorio, nunca pdfLaTeX)
 - **Clase principal:** `cls/eps-tfg.cls` (basada en KOMA-Script `scrbook`)
 - **Bibliografía:** BibLaTeX + Biber, estilo APA 7
@@ -308,6 +308,7 @@ Formato de entrada en `referencias.bib`:
 
 | Error en `.log` | Causa | Solución |
 | --- | --- | --- |
+| `TeX capacity exceeded [main memory size=5000000]` | Motor incorrecto (XeLaTeX/pdfLaTeX) | Compilar con LuaLaTeX; en Overleaf, Menu → Compiler → LuaLaTeX (`docs/OVERLEAF.md`) |
 | `Undefined control sequence \EPSsetup` | `configuracion.tex` cargado antes de la clase | Verificar orden en `main.tex` |
 | `You must invoke LaTeX with -shell-escape` | Falta flag en compilación | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | `latexminted` no instalado | `pip install latexminted` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,7 +308,8 @@ Formato de entrada en `referencias.bib`:
 
 | Error en `.log` | Causa | Solución |
 | --- | --- | --- |
-| `TeX capacity exceeded [main memory size=5000000]` | Motor incorrecto (XeLaTeX/pdfLaTeX) | Compilar con LuaLaTeX; en Overleaf, Menu → Compiler → LuaLaTeX (`docs/OVERLEAF.md`) |
+| `TeX capacity exceeded [main memory size=5000000]` | Casi siempre, motor incorrecto (XeLaTeX/pdfLaTeX, de memoria fija); si el motor ya es LuaLaTeX, revisar el contexto en `main.log` (macro recursiva, documento enorme) | Compilar con LuaLaTeX; en Overleaf, Menu → Compiler → LuaLaTeX (`docs/OVERLEAF.md`) |
+| `ESTA PLANTILLA REQUIERE LuaLaTeX` | Guard de motor de la plantilla: el motor no es LuaTeX | Compilar con LuaLaTeX (`make`) |
 | `Undefined control sequence \EPSsetup` | `configuracion.tex` cargado antes de la clase | Verificar orden en `main.tex` |
 | `You must invoke LaTeX with -shell-escape` | Falta flag en compilación | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | `latexminted` no instalado | `pip install latexminted` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Todos los cambios notables de este proyecto serán documentados en este archivo.
 El formato está basado en [Keep a Changelog](https://keepachangelog.com/es-ES/1.0.0/),
 y este proyecto adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
+## [2.2.2] - 2026-08-02
+
+### Añadido
+
+- **Guía de Overleaf**: Nueva guía `docs/OVERLEAF.md` (importación, selección de
+  compilador, límites de compilación, avisos normales y errores frecuentes)
+- **Botón «Abrir en Overleaf»** en el README, que crea el proyecto con el motor
+  LuaLaTeX ya seleccionado (`engine=lualatex`)
+- **Comprobación de motor** en `cls/eps-metadata.tex`: si se compila con
+  pdfLaTeX o XeLaTeX, la compilación se detiene con un mensaje explicativo en
+  lugar del error críptico `TeX capacity exceeded, sorry [main memory size=5000000]`
+
+### Corregido
+
+- **Compatibilidad con Overleaf**: `.latexmkrc` redirige los motores `pdflatex`,
+  `xelatex` y `latex` a LuaLaTeX. Overleaf ignora la línea mágica
+  `% !TeX program = lualatex` y pasa el motor por línea de órdenes (prioritaria
+  sobre `$pdf_mode`), por lo que los proyectos importados fallaban al compilar
+  con XeLaTeX/pdfLaTeX
+
+---
+
 ## [2.1.0] - 2026-02-06
 
 ### Añadido

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ y este proyecto adhiere a [Versionado Semántico](https://semver.org/lang/es/).
 
 - **Guía de Overleaf**: Nueva guía `docs/OVERLEAF.md` (importación, selección de
   compilador, límites de compilación, avisos normales y errores frecuentes)
+- **Plantilla publicada en la galería de Overleaf**, enlazada desde el README,
+  `docs/OVERLEAF.md`, `docs/README.md`, `docs/GUIA_PRINCIPIANTES.md` y `llms.txt`
 - **Botón «Abrir en Overleaf»** en el README, que crea el proyecto con el motor
   LuaLaTeX ya seleccionado (`engine=lualatex`)
 - **Comprobación de motor** en `cls/eps-metadata.tex`: si se compila con

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "Si utilizas esta plantilla, por favor cítala como se indica a continuación."
 type: software
 title: "Plantilla LaTeX TFG/TFM — Escuela Politécnica Superior (Universidad de Alicante)"
-version: 2.2.1
-date-released: 2026-07-11
+version: 2.2.2
+date-released: 2026-08-02
 doi: "10.5281/zenodo.21315904"
 authors:
   - family-names: "Requena Plens"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md — Instrucciones para Claude
 
 Plantilla LaTeX para TFG/TFM de la Escuela Politécnica Superior (EPS),
-Universidad de Alicante. Versión 2.2.1 (2026).
+Universidad de Alicante. Versión 2.2.2 (2026).
 
 Motor: **LuaLaTeX** (obligatorio). Bibliografía: **BibLaTeX + Biber** (APA 7).
 Código: **minted 3.x** con `latexminted`.
@@ -476,6 +476,8 @@ Si el usuario reporta un error, pedir las últimas 30 líneas de `main.log`.
 
 | Error | Causa probable | Solución |
 | --- | --- | --- |
+| `TeX capacity exceeded [main memory size=5000000]` | Se está compilando con XeLaTeX/pdfLaTeX | Usar LuaLaTeX (en Overleaf: Menu → Compiler → LuaLaTeX). Ver `docs/OVERLEAF.md` |
+| `ESTA PLANTILLA REQUIERE LuaLaTeX` | Guard de motor en `cls/eps-metadata.tex` | Ídem |
 | `Undefined control sequence` | Comando no definido o paquete no cargado | Verificar módulo de componentes activo |
 | `You must invoke LaTeX with -shell-escape` | Falta flag | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | Python/minted no instalado | `pip install latexminted` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -476,8 +476,8 @@ Si el usuario reporta un error, pedir las últimas 30 líneas de `main.log`.
 
 | Error | Causa probable | Solución |
 | --- | --- | --- |
-| `TeX capacity exceeded [main memory size=5000000]` | Se está compilando con XeLaTeX/pdfLaTeX | Usar LuaLaTeX (en Overleaf: Menu → Compiler → LuaLaTeX). Ver `docs/OVERLEAF.md` |
-| `ESTA PLANTILLA REQUIERE LuaLaTeX` | Guard de motor en `cls/eps-metadata.tex` | Ídem |
+| `TeX capacity exceeded [main memory size=5000000]` | Causa más probable: se está compilando con XeLaTeX/pdfLaTeX (memoria fija). También puede deberse a una macro recursiva o a un documento desmesurado | Comprobar primero el motor: usar LuaLaTeX (en Overleaf: Menu → Compiler → LuaLaTeX). Si ya se usa LuaLaTeX, revisar el contexto del error en `main.log`. Ver `docs/OVERLEAF.md` |
+| `ESTA PLANTILLA REQUIERE LuaLaTeX` | Guard de motor en `cls/eps-metadata.tex`: el motor no es LuaTeX | Compilar con LuaLaTeX (`make`, o en Overleaf Menu → Compiler → LuaLaTeX) |
 | `Undefined control sequence` | Comando no definido o paquete no cargado | Verificar módulo de componentes activo |
 | `You must invoke LaTeX with -shell-escape` | Falta flag | Usar `make` o añadir `-shell-escape` |
 | `Pygments not found` | Python/minted no instalado | `pip install latexminted` |

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Autor:    José Manuel Requena Plens
 # Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 # Licencia: MIT
-# Versión:  2.2.1
+# Versión:  2.2.2
 # ==============================================================================
 #
 # Comandos disponibles:

--- a/README.md
+++ b/README.md
@@ -590,7 +590,7 @@ o hacerlo a mano:
 > porque el preámbulo de la plantilla no cabe en la memoria fija de esos motores.
 > El `.latexmkrc` del proyecto redirige el motor a LuaLaTeX como red de
 > seguridad, pero conviene ajustar el menú igualmente.
-
+>
 > 💡 `shell-escape` (necesario para minted) lo activa Overleaf automáticamente al
 > detectar el paquete; no hay que configurar nada.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Universidad de Alicante
 
 [![LaTeX](https://img.shields.io/badge/LaTeX-LuaLaTeX-008080?logo=latex)](https://www.latex-project.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Version](https://img.shields.io/badge/Versión-2.2.1-blue.svg)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
+[![Version](https://img.shields.io/badge/Versión-2.2.2-blue.svg)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21315904-blue?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.21315904)
 [![listed on awesome-comunitat-valenciana](https://img.shields.io/badge/listed%20on-awesome--comunitat--valenciana-FFB81C?style=flat&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCI+PGcgZmlsbD0iI0ZGQjgxQyI+PHJlY3QgeD0iNiIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjQiIHk9IjQiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI4IiB5PSI0IiB3aWR0aD0iMiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iMiIgeT0iMyIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjEwIiB5PSIzIiB3aWR0aD0iMiIgaGVpZ2h0PSI0Ii8+PHJlY3QgeD0iMCIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iMyIvPjxyZWN0IHg9IjEyIiB5PSIyIiB3aWR0aD0iMiIgaGVpZ2h0PSIzIi8+PHJlY3QgeD0iNSIgeT0iOCIgd2lkdGg9IjQiIGhlaWdodD0iMiIvPjxyZWN0IHg9IjQiIHk9IjEwIiB3aWR0aD0iNiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iNSIgeT0iMTIiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI3IiB5PSIxMiIgd2lkdGg9IjIiIGhlaWdodD0iMiIvPjwvZz48L3N2Zz4=&labelColor=0056A0)](https://github.com/GeiserX/awesome-comunitat-valenciana#readme)
 
@@ -562,12 +562,26 @@ Los colores de las titulaciones se definen en la clase. Para personalizar:
 
 ## 🌐 Uso en Overleaf
 
-1. Sube todos los archivos del proyecto a Overleaf
-2. Configura el compilador como **LuaLaTeX**
-3. Activa **shell-escape** en la configuración del proyecto
+[![Abrir en Overleaf](https://img.shields.io/badge/Abrir%20en-Overleaf-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/docs?snip_uri=https://github.com/jmrplens/TFG-TFM_EPS/archive/refs/heads/main.zip&engine=lualatex)
+
+1. Sube todos los archivos del proyecto a Overleaf (o usa el botón anterior, que
+   ya deja seleccionado LuaLaTeX)
+2. **Menu → Compiler → LuaLaTeX** ⚠️ *paso imprescindible*
+3. **Menu → TeX Live version → 2025** (o la más reciente)
 4. Compila `main.tex`
 
-> ⚠️ **Nota:** Algunas funcionalidades como minted requieren shell-escape habilitado.
+> ⚠️ **Overleaf ignora la línea `% !TeX program = lualatex`** de `main.tex`: el
+> motor se elige solo desde el menú *Compiler*. Con pdfLaTeX o XeLaTeX la
+> compilación falla con `TeX capacity exceeded, sorry [main memory size=5000000]`
+> porque el preámbulo de la plantilla no cabe en la memoria fija de esos motores.
+> El `.latexmkrc` del proyecto redirige el motor a LuaLaTeX como red de
+> seguridad, pero conviene ajustar el menú igualmente.
+
+> 💡 `shell-escape` (necesario para minted) lo activa Overleaf automáticamente al
+> detectar el paquete; no hay que configurar nada.
+
+📖 **Guía completa:** [`docs/OVERLEAF.md`](docs/OVERLEAF.md) — importación,
+límites de compilación, avisos normales y solución de errores.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -566,8 +566,12 @@ Los colores de las titulaciones se definen en la clase. Para personalizar:
 
 [![Plantilla en Overleaf](https://img.shields.io/badge/Overleaf-Abrir%20plantilla-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
 
-**La forma más rápida:** abre la
-[plantilla publicada en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
+Overleaf es una **alternativa** al trabajo en local (ver [Inicio
+Rápido](#-inicio-rápido)) para quien no quiera instalar nada o necesite
+colaborar en línea, a cambio de los límites de compilación de la plataforma.
+
+**Dentro de Overleaf, la vía más cómoda:** abre la
+[plantilla publicada en la galería](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
 y pulsa *Open as Template*: el proyecto se crea con el compilador y la versión
 de TeX Live ya configurados.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Plantilla LaTeX moderna y profesional para la elaboración de **Trabajos de Fin 
 - 📊 **Gráficas y diagramas** con TikZ/PGFPlots
 - 📖 **Glosarios y acrónimos** integrados
 - 🚀 **Optimización TikZ** con caché de figuras
-- 🔧 **Compatible con Overleaf** y editores locales
+- 🔧 **Pensada para trabajar en local** (VS Code, TeXstudio…) y **compatible con Overleaf**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Universidad de Alicante
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Version](https://img.shields.io/badge/Versión-2.2.2-blue.svg)](https://github.com/jmrplens/TFG-TFM_EPS/releases)
 [![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.21315904-blue?logo=doi&logoColor=white)](https://doi.org/10.5281/zenodo.21315904)
+[![Overleaf](https://img.shields.io/badge/Overleaf-Plantilla%20publicada-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
 [![listed on awesome-comunitat-valenciana](https://img.shields.io/badge/listed%20on-awesome--comunitat--valenciana-FFB81C?style=flat&logo=data:image/svg%2bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNCAxNCI+PGcgZmlsbD0iI0ZGQjgxQyI+PHJlY3QgeD0iNiIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjQiIHk9IjQiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI4IiB5PSI0IiB3aWR0aD0iMiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iMiIgeT0iMyIgd2lkdGg9IjIiIGhlaWdodD0iNCIvPjxyZWN0IHg9IjEwIiB5PSIzIiB3aWR0aD0iMiIgaGVpZ2h0PSI0Ii8+PHJlY3QgeD0iMCIgeT0iMiIgd2lkdGg9IjIiIGhlaWdodD0iMyIvPjxyZWN0IHg9IjEyIiB5PSIyIiB3aWR0aD0iMiIgaGVpZ2h0PSIzIi8+PHJlY3QgeD0iNSIgeT0iOCIgd2lkdGg9IjQiIGhlaWdodD0iMiIvPjxyZWN0IHg9IjQiIHk9IjEwIiB3aWR0aD0iNiIgaGVpZ2h0PSIyIi8+PHJlY3QgeD0iNSIgeT0iMTIiIHdpZHRoPSIyIiBoZWlnaHQ9IjIiLz48cmVjdCB4PSI3IiB5PSIxMiIgd2lkdGg9IjIiIGhlaWdodD0iMiIvPjwvZz48L3N2Zz4=&labelColor=0056A0)](https://github.com/GeiserX/awesome-comunitat-valenciana#readme)
 
 Plantilla LaTeX moderna y profesional para la elaboración de **Trabajos de Fin de Grado (TFG)** y **Trabajos de Fin de Máster (TFM)** de la Escuela Politécnica Superior de la Universidad de Alicante.
@@ -54,6 +55,7 @@ Esta plantilla incluye una documentación exhaustiva para cada aspecto de tu TFG
 
 | Guía | Descripción |
 | ------ | ------------- |
+| 🌐 [Uso en Overleaf](docs/OVERLEAF.md) | Plantilla en la galería, compilador LuaLaTeX, límites de compilación y errores |
 | 📝 [Código Fuente](docs/CODIGO_FUENTE.md) | Insertar y resaltar código con minted (40+ lenguajes) |
 | 📊 [Figuras y Gráficas](docs/FIGURAS_GRAFICAS.md) | Crear gráficos con pgfplots y TikZ |
 | 🖼️ [Imágenes y Subfiguras](docs/IMAGENES_SUBFIGURAS.md) | Incluir imágenes, subfiguras y posicionamiento |
@@ -562,10 +564,18 @@ Los colores de las titulaciones se definen en la clase. Para personalizar:
 
 ## 🌐 Uso en Overleaf
 
-[![Abrir en Overleaf](https://img.shields.io/badge/Abrir%20en-Overleaf-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/docs?snip_uri=https://github.com/jmrplens/TFG-TFM_EPS/archive/refs/heads/main.zip&engine=lualatex)
+[![Plantilla en Overleaf](https://img.shields.io/badge/Overleaf-Abrir%20plantilla-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
 
-1. Sube todos los archivos del proyecto a Overleaf (o usa el botón anterior, que
-   ya deja seleccionado LuaLaTeX)
+**La forma más rápida:** abre la
+[plantilla publicada en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
+y pulsa *Open as Template*: el proyecto se crea con el compilador y la versión
+de TeX Live ya configurados.
+
+Si prefieres subir este repositorio completo (con todo el contenido de ejemplo),
+puedes usar [este enlace](https://www.overleaf.com/docs?snip_uri=https://github.com/jmrplens/TFG-TFM_EPS/archive/refs/heads/main.zip&engine=lualatex)
+o hacerlo a mano:
+
+1. Sube todos los archivos del proyecto a Overleaf
 2. **Menu → Compiler → LuaLaTeX** ⚠️ *paso imprescindible*
 3. **Menu → TeX Live version → 2025** (o la más reciente)
 4. Compila `main.tex`

--- a/cls/eps-metadata.tex
+++ b/cls/eps-metadata.tex
@@ -5,6 +5,29 @@
 % Se carga ANTES de \documentclass para asegurar que el motor PDF se
 % inicialice correctamente.
 
+% -----------------------------------------------------------------------------
+% COMPROBACIÓN DEL MOTOR: la plantilla SOLO funciona con LuaLaTeX
+% -----------------------------------------------------------------------------
+% Con pdfLaTeX o XeLaTeX el documento falla más adelante con errores confusos
+% (típicamente «TeX capacity exceeded, sorry [main memory size=5000000]»,
+% porque esos motores tienen memoria fija y el preámbulo de esta plantilla no
+% cabe en ella). Abortamos aquí con un mensaje claro.
+\ifdefined\directlua\else
+  \newlinechar=`\^^J
+  \errmessage{^^J%
+  ============================================================^^J%
+   ESTA PLANTILLA REQUIERE LuaLaTeX (motor actual: no es LuaTeX)^^J%
+  ============================================================^^J%
+   * Overleaf: Menu -> Settings -> Compiler -> LuaLaTeX^^J%
+     (Overleaf ignora la linea magica "!TeX program = lualatex")^^J%
+   * Local:    make    o    lualatex -shell-escape main.tex^^J%
+   * latexmk:  latexmk main.tex   (usa .latexmkrc del proyecto)^^J%
+  ^^J%
+   Mas informacion: docs/OVERLEAF.md^^J%
+  ============================================================^^J}%
+  \csname @@end\endcsname
+\fi
+
 \DocumentMetadata{
   % --- Fase de pruebas de accesibilidad (tagging) ---
   % phase-I:  Etiquetado básico automático.

--- a/cls/eps-tfg.cls
+++ b/cls/eps-tfg.cls
@@ -5,11 +5,29 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}[2022/06/01]
-\ProvidesClass{eps-tfg}[2026/07/11 v2.2.1 Clase TFG/TFM EPS Universidad de Alicante]
+\ProvidesClass{eps-tfg}[2026/08/02 v2.2.2 Clase TFG/TFM EPS Universidad de Alicante]
+
+%% ============================================================================
+%% COMPROBACIÓN DEL MOTOR: LuaLaTeX obligatorio
+%% ============================================================================
+%% Con pdfLaTeX o XeLaTeX el documento falla más adelante con errores confusos
+%% (p. ej. «TeX capacity exceeded»). Normalmente esto ya se detecta en
+%% cls/eps-metadata.tex; esta comprobación cubre el caso de cargar la clase sin
+%% ese archivo. Ver docs/OVERLEAF.md.
+\ifdefined\directlua\else
+  \ClassError{eps-tfg}{%
+    Esta plantilla requiere LuaLaTeX\MessageBreak
+    (en Overleaf: Menu -> Compiler -> LuaLaTeX)%
+  }{%
+    Compila con `make' o `lualatex -shell-escape main.tex'.\MessageBreak
+    Mas informacion en docs/OVERLEAF.md%
+  }%
+  \csname @@end\endcsname
+\fi
 
 %% ============================================================================
 %% ARQUITECTURA DE LA CLASE

--- a/configuracion.tex
+++ b/configuracion.tex
@@ -4,7 +4,7 @@
 %%
 %% Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 %% Autor:    José Manuel Requena Plens
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %% =============================================================================
 %
 % Este archivo contiene toda la información personal y del trabajo.

--- a/docs/GUIA_PRINCIPIANTES.md
+++ b/docs/GUIA_PRINCIPIANTES.md
@@ -182,13 +182,20 @@ Si prefieres instalar manualmente, sigue las opciones a continuación.
 [Overleaf](https://www.overleaf.com) es un editor LaTeX online. No necesitas instalar nada.
 
 1. Crea una cuenta en [overleaf.com](https://www.overleaf.com)
-2. Sube los archivos de la plantilla (o usa "Upload Project" con el ZIP)
-3. Configura el compilador como **LuaLaTeX** (menú ☰ → Settings)
-4. ¡Listo! Puedes empezar a editar
+2. Abre la [plantilla publicada en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
+   y pulsa **Open as Template**: el proyecto se crea con el compilador correcto
+   ya configurado
+3. ¡Listo! Puedes empezar a editar
+
+Si en vez de eso subes los archivos tú (*Upload Project* con el ZIP), configura
+el compilador como **LuaLaTeX** en menú ☰ → *Compiler*. Es imprescindible: con
+pdfLaTeX o XeLaTeX la compilación falla.
 
 **Ventajas:** Sin instalación, funciona en cualquier ordenador, colaboración en tiempo real.
 
 **Desventajas:** Necesitas internet, versión gratuita tiene límite de tiempo de compilación.
+
+📖 Guía completa de Overleaf: [`OVERLEAF.md`](OVERLEAF.md)
 
 ### Opción 2: Instalación local en Windows
 

--- a/docs/GUIA_PRINCIPIANTES.md
+++ b/docs/GUIA_PRINCIPIANTES.md
@@ -20,10 +20,11 @@ Si vienes de Word, Google Docs o similar, LaTeX puede parecer intimidante al pri
   - [Entornos](#entornos)
   - [Comentarios](#comentarios)
 - [💻 Instalación paso a paso](#-instalación-paso-a-paso)
-  - [Opción 1: Overleaf (sin instalar nada) Recomendado para empezar ⭐](#opción-1-overleaf-sin-instalar-nada-recomendado-para-empezar)
-  - [Opción 2: Instalación local en Windows](#opción-2-instalación-local-en-windows)
-  - [Opción 3: Instalación local en macOS](#opción-3-instalación-local-en-macos)
-  - [Opción 4: Instalación local en Linux (Ubuntu/Debian)](#opción-4-instalación-local-en-linux-ubuntudebian)
+  - [Opción 0: Script de instalación automática ⭐ Recomendado para instalación local](#opción-0-script-de-instalación-automática--recomendado-para-instalación-local)
+  - [Opción 1: Instalación local en Windows](#opción-1-instalación-local-en-windows)
+  - [Opción 2: Instalación local en macOS](#opción-2-instalación-local-en-macos)
+  - [Opción 3: Instalación local en Linux (Ubuntu/Debian)](#opción-3-instalación-local-en-linux-ubuntudebian)
+  - [Opción 4: Overleaf (alternativa sin instalación)](#opción-4-overleaf-alternativa-sin-instalación)
 - [✍️ Eligiendo un editor](#eligiendo-un-editor)
   - [VS Code + LaTeX Workshop Recomendado ⭐](#vs-code--latex-workshop-recomendado)
   - [TeXstudio - Alternativa popular](#texstudio---alternativa-popular)
@@ -177,27 +178,7 @@ Si prefieres que una IA te guíe paso a paso, usa el **agente de instalación**:
 
 Si prefieres instalar manualmente, sigue las opciones a continuación.
 
-### Opción 1: Overleaf (sin instalar nada) Recomendado para empezar⭐
-
-[Overleaf](https://www.overleaf.com) es un editor LaTeX online. No necesitas instalar nada.
-
-1. Crea una cuenta en [overleaf.com](https://www.overleaf.com)
-2. Abre la [plantilla publicada en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
-   y pulsa **Open as Template**: el proyecto se crea con el compilador correcto
-   ya configurado
-3. ¡Listo! Puedes empezar a editar
-
-Si en vez de eso subes los archivos tú (*Upload Project* con el ZIP), configura
-el compilador como **LuaLaTeX** en menú ☰ → *Compiler*. Es imprescindible: con
-pdfLaTeX o XeLaTeX la compilación falla.
-
-**Ventajas:** Sin instalación, funciona en cualquier ordenador, colaboración en tiempo real.
-
-**Desventajas:** Necesitas internet, versión gratuita tiene límite de tiempo de compilación.
-
-📖 Guía completa de Overleaf: [`OVERLEAF.md`](OVERLEAF.md)
-
-### Opción 2: Instalación local en Windows
+### Opción 1: Instalación local en Windows
 
 #### Paso 1: Instalar MiKTeX
 
@@ -218,7 +199,7 @@ pdfLaTeX o XeLaTeX la compilación falla.
 
 #### Paso 3: Instalar un editor (ver sección siguiente)
 
-### Opción 3: Instalación local en macOS
+### Opción 2: Instalación local en macOS
 
 #### Paso 1: Instalar MacTeX
 
@@ -232,7 +213,7 @@ pdfLaTeX o XeLaTeX la compilación falla.
 pip3 install latexminted
 ```
 
-### Opción 4: Instalación local en Linux (Ubuntu/Debian)
+### Opción 3: Instalación local en Linux (Ubuntu/Debian)
 
 ```bash
 # Instalar TeX Live completo (recomendado, ~5GB)
@@ -247,6 +228,31 @@ pip3 install latexminted
 ```
 
 > **Nota:** Ubuntu/Debian pueden tener versiones antiguas de TeX Live en sus repositorios. Para obtener TeX Live 2025, considera usar la [instalación oficial de TeX Live](https://www.tug.org/texlive/quickinstall.html) en lugar de los paquetes de la distribución.
+
+### Opción 4: Overleaf (alternativa sin instalación)
+
+[Overleaf](https://www.overleaf.com) es un editor LaTeX online: no necesitas instalar nada.
+Es la **alternativa** recomendada solo si no puedes o no quieres trabajar en local
+(por ejemplo, para colaborar en línea o desde un ordenador que no es tuyo).
+
+1. Crea una cuenta en [overleaf.com](https://www.overleaf.com)
+2. Abre la [plantilla publicada en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)
+   y pulsa **Open as Template**: el proyecto se crea con el compilador correcto
+   ya configurado
+3. ¡Listo! Puedes empezar a editar
+
+Si en vez de eso subes los archivos tú (*Upload Project* con el ZIP), configura
+el compilador como **LuaLaTeX** en menú ☰ → *Compiler*. Es imprescindible: con
+pdfLaTeX o XeLaTeX la compilación falla.
+
+**Ventajas:** Sin instalación, funciona en cualquier ordenador, colaboración en tiempo real.
+
+**Desventajas:** Necesitas internet y, sobre todo, **esta plantilla es pesada**: entre
+el etiquetado PDF/UA, `minted` y las figuras TikZ, la primera compilación necesita
+varias pasadas y puede agotar el límite de tiempo del plan gratuito (~20 s). En local
+no existe ese límite. Si trabajas en Overleaf, lee antes
+[`OVERLEAF.md`](OVERLEAF.md): explica cómo elegir el compilador y cómo ir compilando
+por partes.
 
 ---
 
@@ -298,10 +304,10 @@ pip3 install latexminted
 
 | Editor | Facilidad | Características | Para quién |
 | -------- | ----------- | ----------------- | ------------ |
-| **Overleaf** | ⭐⭐⭐⭐⭐ | Online, colaborativo | Principiantes, equipos |
-| **VS Code** | ⭐⭐⭐⭐ | Muy extensible | Programadores, avanzados |
+| **VS Code** ⭐ *recomendado* | ⭐⭐⭐⭐ | Muy extensible, sin límites de compilación | Uso general con esta plantilla |
 | **TeXstudio** | ⭐⭐⭐⭐ | Todo incluido | Uso general |
-| **Texmaker** | ⭐⭐⭐⭐ | Sencillo | Principiantes locales |
+| **Texmaker** | ⭐⭐⭐⭐ | Sencillo | Quien prefiera algo minimalista |
+| **Overleaf** *(alternativa)* | ⭐⭐⭐⭐⭐ | Online, colaborativo, con límite de tiempo de compilación | Trabajo en equipo o sin poder instalar nada |
 
 ---
 

--- a/docs/GUIA_PRINCIPIANTES.md
+++ b/docs/GUIA_PRINCIPIANTES.md
@@ -249,7 +249,7 @@ pdfLaTeX o XeLaTeX la compilación falla.
 
 **Desventajas:** Necesitas internet y, sobre todo, **esta plantilla es pesada**: entre
 el etiquetado PDF/UA, `minted` y las figuras TikZ, la primera compilación necesita
-varias pasadas y puede agotar el límite de tiempo del plan gratuito (~20 s). En local
+varias pasadas y agota el límite de tiempo del plan gratuito (10 s). En local
 no existe ese límite. Si trabajas en Overleaf, lee antes
 [`OVERLEAF.md`](OVERLEAF.md): explica cómo elegir el compilador y cómo ir compilando
 por partes.

--- a/docs/OVERLEAF.md
+++ b/docs/OVERLEAF.md
@@ -9,6 +9,14 @@ confusos. Esta guía explica cómo dejar el proyecto compilando a la primera.
 
 ## ⚡ Resumen rápido
 
+**La vía recomendada es la plantilla publicada en la galería de Overleaf**, que
+ya viene configurada con LuaLaTeX:
+
+👉 **[Plantilla en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)**
+→ *Open as Template*
+
+Si prefieres subir el proyecto tú mismo:
+
 1. **Sube el proyecto** (zip limpio, sin PDF ni archivos auxiliares).
 2. **Menu → Compiler → LuaLaTeX** y **TeX Live version → 2025** (o superior).
 3. **Recompile**. La primera compilación es la más lenta (caché de `minted`).
@@ -19,7 +27,8 @@ confusos. Esta guía explica cómo dejar el proyecto compilando a la primera.
 
 | Método | Cómo |
 | --- | --- |
-| Botón directo | [![Abrir en Overleaf](https://img.shields.io/badge/Abrir%20en-Overleaf-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/docs?snip_uri=https://github.com/jmrplens/TFG-TFM_EPS/archive/refs/heads/main.zip&engine=lualatex) — crea el proyecto **ya configurado con LuaLaTeX** |
+| **Galería de Overleaf** (recomendado) | [Abrir la plantilla publicada](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv) → *Open as Template*. El compilador y la versión de TeX Live vienen ya configurados |
+| Botón directo desde GitHub | [![Abrir en Overleaf](https://img.shields.io/badge/Abrir%20en-Overleaf-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/docs?snip_uri=https://github.com/jmrplens/TFG-TFM_EPS/archive/refs/heads/main.zip&engine=lualatex) — crea el proyecto con **todo el contenido de ejemplo** (más pesado de compilar, ver [sección 5](#5-tiempos-de-compilación-límites-de-overleaf)) |
 | Subida manual | GitHub → *Code* → *Download ZIP* → Overleaf → *New Project* → *Upload Project* |
 | GitHub Sync | Solo en planes de pago: *New Project* → *Import from GitHub* |
 

--- a/docs/OVERLEAF.md
+++ b/docs/OVERLEAF.md
@@ -1,0 +1,217 @@
+# 🌐 Guía de uso en Overleaf
+
+Esta plantilla funciona en [Overleaf](https://www.overleaf.com), pero **solo con
+LuaLaTeX**. Overleaf compila por defecto con pdfLaTeX (y a veces selecciona
+XeLaTeX al importar proyectos con fuentes OpenType), lo que produce errores
+confusos. Esta guía explica cómo dejar el proyecto compilando a la primera.
+
+---
+
+## ⚡ Resumen rápido
+
+1. **Sube el proyecto** (zip limpio, sin PDF ni archivos auxiliares).
+2. **Menu → Compiler → LuaLaTeX** y **TeX Live version → 2025** (o superior).
+3. **Recompile**. La primera compilación es la más lenta (caché de `minted`).
+
+---
+
+## 1. Importar el proyecto
+
+| Método | Cómo |
+| --- | --- |
+| Botón directo | [![Abrir en Overleaf](https://img.shields.io/badge/Abrir%20en-Overleaf-47A141?logo=overleaf&logoColor=white)](https://www.overleaf.com/docs?snip_uri=https://github.com/jmrplens/TFG-TFM_EPS/archive/refs/heads/main.zip&engine=lualatex) — crea el proyecto **ya configurado con LuaLaTeX** |
+| Subida manual | GitHub → *Code* → *Download ZIP* → Overleaf → *New Project* → *Upload Project* |
+| GitHub Sync | Solo en planes de pago: *New Project* → *Import from GitHub* |
+
+> ⚠️ **Sube el proyecto limpio.** Si el zip incluye el PDF y los auxiliares
+> (`main.pdf`, `main.aux`, `_minted/`…), Overleaf puede mostrar avisos como
+> *«This project contains a file called output.pdf»* y no enseñar el PDF
+> generado. Un `git clone` o el ZIP de GitHub ya vienen limpios (están en
+> `.gitignore`); si compilaste en local, ejecuta `make clean` antes de subir.
+
+---
+
+## 2. Seleccionar el compilador (paso imprescindible)
+
+**Menu** (esquina superior izquierda) → **Compiler** → **LuaLaTeX**.
+
+Overleaf **ignora** la línea mágica `% !TeX program = lualatex` que hay al
+principio de `main.tex`: el motor se elige únicamente desde ese menú (o con el
+parámetro `engine=lualatex` en el enlace «Abrir en Overleaf»).
+
+### Red de seguridad incluida en la plantilla
+
+Aunque olvides ese paso, el proyecto trae dos protecciones:
+
+- **`.latexmkrc`**: redirige `pdflatex`, `xelatex` y `latex` a LuaLaTeX, de modo
+  que Overleaf compila con LuaLaTeX aunque el menú indique otro motor. Verás en
+  los logs un aviso inocuo (`lualatex: unrecognized option '-no-pdf'`) y una
+  pasada extra: por eso conviene ajustar el menú de todos modos.
+- **`cls/eps-metadata.tex`**: si por lo que sea se ejecuta pdfLaTeX o XeLaTeX
+  directamente, la compilación se detiene con un mensaje claro
+  (*ESTA PLANTILLA REQUIERE LuaLaTeX*) en lugar del críptico
+  `TeX capacity exceeded, sorry [main memory size=5000000]`.
+
+> 🧹 **Tras cambiar de compilador, limpia la caché.** En el panel de logs pulsa
+> *Logs and output files* → **Clear cached files**. Los auxiliares que dejó la
+> compilación fallida (`output.aux`, `output.xdv`, `output.bcf`…) pueden
+> provocar errores extraños en la primera compilación con el motor nuevo.
+
+> 💡 **¿Por qué falla con XeLaTeX/pdfLaTeX?** Esos motores tienen una memoria
+> principal fija (5.000.000 de palabras) que no se puede ampliar en Overleaf. El
+> preámbulo de la plantilla (KOMA + tagging PDF/UA + biblatex + glossaries +
+> tcolorbox + minted + los módulos de componentes) no cabe en ella. LuaTeX
+> reserva memoria dinámicamente y no tiene ese límite.
+
+---
+
+## 3. Versión de TeX Live
+
+**Menu → TeX Live version → 2025** (o la más reciente disponible).
+
+| Componente | Versión mínima | Motivo |
+| --- | --- | --- |
+| TeX Live | 2024 (recomendado 2025) | `\DocumentMetadata`, tagging PDF/UA-2 |
+| minted | 3.x | Entornos de código (`pythoncode`, `jscode`…) |
+| biblatex | 3.19+ | Estilo APA 7 con Biber |
+
+Con TeX Live 2023 o anterior fallará el tagging PDF/UA y `minted` 3.
+
+---
+
+## 4. minted y `shell-escape`
+
+Los entornos de código usan **minted 3**, que necesita `shell-escape`. No hay
+que hacer nada: Overleaf lo activa automáticamente al detectar `minted`, y el
+`.latexmkrc` de la plantilla también lo pasa explícitamente.
+
+Si aun así aparece `You must invoke LaTeX with -shell-escape`, comprueba que la
+versión de TeX Live sea 2024 o posterior.
+
+---
+
+## 5. Tiempos de compilación (límites de Overleaf)
+
+Overleaf corta la compilación al llegar al límite del plan:
+
+| Plan | Límite aproximado |
+| --- | --- |
+| Gratuito | ~20 segundos |
+| Premium | 240 segundos (4 minutos) |
+
+El proyecto **tal cual se descarga** (más de 130 páginas de contenido de
+ejemplo, todos los módulos de componentes y decenas de bloques `minted`) es
+demasiado pesado para el plan gratuito, y una compilación completa
+(varias pasadas + Biber + glosarios) puede rozar también el límite de 240 s del
+plan premium. Para tu TFG/TFM real, en cuanto sustituyas el contenido de
+ejemplo, el tiempo baja drásticamente: lo que pesa es la *demostración* de
+componentes, no la plantilla.
+
+### Cómo reducir el tiempo de compilación
+
+1. **Carga solo el módulo de tu titulación** en `main.tex` (el ejemplo trae
+   `[all]`, que carga todos):
+
+   ```latex
+   % \usepackage[all]{eps-componentes}      % <- lento: carga todo
+   \usepackage[software]{eps-componentes}   % <- solo lo que necesitas
+   ```
+
+2. **Sustituye el contenido de ejemplo** por el tuyo. Los capítulos de
+   demostración (`contenido/capitulos/`) existen para enseñar componentes y son
+   la mayor parte del coste.
+3. **No borres la caché**: Overleaf reutiliza la carpeta `_minted` entre
+   compilaciones. La primera compilación siempre es la más lenta.
+4. **Comenta capítulos mientras escribes** (`\input`) y descoméntalos al final.
+5. Activa **Stop on first error** para no perder tiempo con errores en cadena.
+
+### Estrategia para la primera compilación (compilación progresiva)
+
+El problema no es una pasada suelta, sino que la **primera** compilación necesita
+varias pasadas seguidas (LaTeX → glosarios → Biber → LaTeX ×3) para resolver
+índices, citas y referencias cruzadas, y todas juntas superan el límite:
+
+| Situación (medido en local, documento de ejemplo completo) | Tiempo |
+| --- | --- |
+| Primera compilación completa (4-5 pasadas + Biber + glosarios) | varios minutos (≈5-10) |
+| Recompilación posterior (1 pasada, auxiliares y caché ya generados) | ~70-90 s |
+
+*(Los tiempos absolutos dependen de la máquina; lo relevante es la proporción:
+la primera compilación cuesta 4-5 veces más que las siguientes.)*
+
+Como Overleaf conserva los archivos auxiliares y la caché de `minted` entre
+compilaciones, se puede **construir el documento por partes**:
+
+1. Comenta casi todos los `\input` de capítulos en `main.tex` y compila.
+2. Descomenta uno o dos capítulos más y vuelve a compilar.
+3. Repite hasta tener el documento completo.
+
+Cada compilación reutiliza el trabajo de la anterior (`.aux`, `.toc`, `.bbl`,
+`_minted`), así que ninguna llega al límite de tiempo aunque el documento final
+sí lo superaría desde cero. Es la forma normal de trabajar en Overleaf con
+documentos grandes, y además es cómoda mientras escribes.
+
+> ⚠️ Si en algún momento pulsas **Clear cached files**, la siguiente compilación
+> vuelve a ser «desde cero»: repite el proceso progresivo.
+
+> ℹ️ Desactivar el etiquetado de accesibilidad (comentar `testphase={phase-I}` y
+> `pdfstandard=ua-2` en `cls/eps-metadata.tex`) apenas ahorra tiempo (~5 % en
+> las pruebas realizadas) y sacrifica el PDF/UA-2: **no** es la palanca que
+> buscas. El contenido —bloques `minted`, figuras TikZ y tablas largas— es lo
+> que domina el tiempo de compilación.
+
+---
+
+## 6. Avisos normales (no son errores)
+
+Con LuaLaTeX correctamente seleccionado, estos mensajes aparecen en el panel de
+logs y **son inofensivos**:
+
+| Mensaje | Significado |
+| --- | --- |
+| `You have requested document class 'cls/eps-tfg'` | Informativo: la clase está en una subcarpeta |
+| `You have requested package 'sty/eps-...'` | Ídem para los paquetes de la plantilla |
+| `Package pdfmanagement Warning: The loading of package hyperxmp is disabled` | Los metadatos XMP los gestiona `pdfmanagement`, no `hyperxmp` |
+| `Package tracklang Warning: No 'datatool' support for dialect 'spanish'` | Limitación de `datatool`; no afecta a glosarios ni acrónimos |
+| `Index style file output.ist not found` (primera pasada) | `glossaries` lanza `makeindex` antes de escribir el `.ist`; se resuelve en la siguiente pasada |
+| `Underfull \hbox` / `Overfull \hbox` | Avisos tipográficos habituales |
+| `lualatex: unrecognized option '-no-pdf'` | Solo si el menú *Compiler* no está en LuaLaTeX y actúa el `.latexmkrc` |
+
+El aviso `Package tagpdf Warning: engine/output mode xetex doesn't support the
+interword spaces` **sí** indica un problema: significa que estás compilando con
+XeLaTeX. Cambia el compilador a LuaLaTeX.
+
+---
+
+## 7. Errores frecuentes
+
+| Error | Causa | Solución |
+| --- | --- | --- |
+| `TeX capacity exceeded, sorry [main memory size=5000000]` | Compilando con XeLaTeX o pdfLaTeX | Menu → Compiler → **LuaLaTeX** |
+| `ESTA PLANTILLA REQUIERE LuaLaTeX` | Ídem (mensaje propio de la plantilla) | Ídem |
+| `This compile didn't produce a PDF` + `output.pdf` en el proyecto | Subiste PDFs/auxiliares junto al fuente | Borra `main.pdf`, `output.pdf` y auxiliares del proyecto |
+| `Timed out` / *compile timeout* | El documento de ejemplo completo no cabe en el límite del plan | Compilación progresiva y reducción de contenido: ver [sección 5](#5-tiempos-de-compilación-límites-de-overleaf) |
+| `File 'eps-tfg.cls' not found` | Se subió solo `main.tex` | Sube el proyecto completo con sus carpetas (`cls/`, `sty/`, `contenido/`…) |
+| `Citation 'X' undefined` o glosario vacío | Falta una pasada de Biber/makeglossaries | Pulsa *Recompile* otra vez; Overleaf los ejecuta vía `latexmk` |
+| `Package minted Error: ... latexminted` | TeX Live antiguo | Menu → TeX Live version → 2025 |
+| Errores raros justo después de cambiar de compilador | Auxiliares de la compilación anterior | *Logs and output files* → **Clear cached files** y recompila |
+
+---
+
+## 8. Diferencias con la compilación local
+
+| | Local (`make`) | Overleaf |
+| --- | --- | --- |
+| Motor | LuaLaTeX (fijado en el `Makefile`) | El del menú *Compiler* (redirigido a LuaLaTeX por `.latexmkrc`) |
+| Orquestación | `make` / `latexmk` | Siempre `latexmk` |
+| Nombre del trabajo | `main` | `output` (los logs hablan de `output.log`, `output.pdf`…) |
+| Bibliografía y glosarios | `biber` + `makeglossaries` desde `.latexmkrc` | Igual (Overleaf lee el `.latexmkrc` del proyecto) |
+
+---
+
+## 📚 Enlaces
+
+- [Selecting a TeX Live version and LaTeX compiler](https://docs.overleaf.com/getting-started/recompiling-your-project/selecting-a-tex-live-version-and-latex-compiler)
+- [Fixing and preventing compile timeouts](https://docs.overleaf.com/troubleshooting-and-support/fixing-and-preventing-compile-timeouts)
+- [Plan limits](https://docs.overleaf.com/getting-started/free-and-premium-plans/plan-limits)
+- [`docs/GUIA_PRINCIPIANTES.md`](GUIA_PRINCIPIANTES.md) — primeros pasos con la plantilla

--- a/docs/OVERLEAF.md
+++ b/docs/OVERLEAF.md
@@ -32,6 +32,12 @@ Si prefieres subir el proyecto tú mismo:
 
 ## 1. Importar el proyecto
 
+> ℹ️ **El repositorio de GitHub es la fuente de la verdad.** La plantilla de la
+> galería se corresponde con la última versión publicada allí y se actualiza
+> reenviándola desde Overleaf, así que puede ir por detrás del repositorio
+> durante un tiempo. Si necesitas la última versión exacta, usa el ZIP de
+> GitHub.
+
 | Método | Cómo |
 | --- | --- |
 | **Galería de Overleaf** (recomendado) | [Abrir la plantilla publicada](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv) → *Open as Template*. El compilador y la versión de TeX Live vienen ya configurados |
@@ -72,7 +78,7 @@ Aunque olvides ese paso, el proyecto trae dos protecciones:
 > *Logs and output files* → **Clear cached files**. Los auxiliares que dejó la
 > compilación fallida (`output.aux`, `output.xdv`, `output.bcf`…) pueden
 > provocar errores extraños en la primera compilación con el motor nuevo.
-
+>
 > 💡 **¿Por qué falla con XeLaTeX/pdfLaTeX?** Esos motores tienen una memoria
 > principal fija (5.000.000 de palabras) que no se puede ampliar en Overleaf. El
 > preámbulo de la plantilla (KOMA + tagging PDF/UA + biblatex + glossaries +
@@ -110,10 +116,13 @@ versión de TeX Live sea 2024 o posterior.
 
 Overleaf corta la compilación al llegar al límite del plan:
 
-| Plan | Límite aproximado |
+| Plan | Límite de compilación |
 | --- | --- |
-| Gratuito | ~20 segundos |
+| Gratuito | 10 segundos |
 | Premium | 240 segundos (4 minutos) |
+
+*(Valores publicados por Overleaf en
+[Plan limits](https://docs.overleaf.com/getting-started/free-and-premium-plans/plan-limits).)*
 
 El proyecto **tal cual se descarga** (más de 130 páginas de contenido de
 ejemplo, todos los módulos de componentes y decenas de bloques `minted`) es
@@ -169,7 +178,7 @@ documentos grandes, y además es cómoda mientras escribes.
 
 > ⚠️ Si en algún momento pulsas **Clear cached files**, la siguiente compilación
 > vuelve a ser «desde cero»: repite el proceso progresivo.
-
+>
 > ℹ️ Desactivar el etiquetado de accesibilidad (comentar `testphase={phase-I}` y
 > `pdfstandard=ua-2` en `cls/eps-metadata.tex`) apenas ahorra tiempo (~5 % en
 > las pruebas realizadas) y sacrifica el PDF/UA-2: **no** es la palanca que

--- a/docs/OVERLEAF.md
+++ b/docs/OVERLEAF.md
@@ -1,5 +1,12 @@
 # 🌐 Guía de uso en Overleaf
 
+> **Nota:** el flujo de trabajo recomendado para esta plantilla es **en local**
+> (TeX Live + un editor como VS Code con LaTeX Workshop, compilando con `make`);
+> ver [Inicio Rápido](../README.md#-inicio-rápido) y la
+> [Guía para Principiantes](GUIA_PRINCIPIANTES.md). **Overleaf es una
+> alternativa** cuando no quieres instalar nada o necesitas colaborar en línea,
+> a cambio de los límites de compilación de la plataforma.
+
 Esta plantilla funciona en [Overleaf](https://www.overleaf.com), pero **solo con
 LuaLaTeX**. Overleaf compila por defecto con pdfLaTeX (y a veces selecciona
 XeLaTeX al importar proyectos con fuentes OpenType), lo que produce errores
@@ -9,8 +16,8 @@ confusos. Esta guía explica cómo dejar el proyecto compilando a la primera.
 
 ## ⚡ Resumen rápido
 
-**La vía recomendada es la plantilla publicada en la galería de Overleaf**, que
-ya viene configurada con LuaLaTeX:
+Si vas a trabajar en Overleaf, **la vía más cómoda es la plantilla publicada en
+la galería**, que ya viene configurada con LuaLaTeX:
 
 👉 **[Plantilla en la galería de Overleaf](https://www.overleaf.com/latex/templates/plantilla-latex-2026-tfg-y-tfm-para-la-eps-de-la-universidad-de-alicante-bachelors-slash-masters-thesis-template/qjntjjjpfjvv)**
 → *Open as Template*

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,7 +5,7 @@ Bienvenido a la documentación detallada de la plantilla TFG/TFM EPS Universidad
 ## 🚀 Guías de Inicio
 
 - **[Guía para Principiantes](GUIA_PRINCIPIANTES.md)**: Si es tu primera vez con LaTeX, empieza por aquí.
-- **[Uso en Overleaf](OVERLEAF.md)**: Plantilla publicada en la galería, selección del compilador (LuaLaTeX), límites de compilación y solución de errores.
+- **[Uso en Overleaf](OVERLEAF.md)**: Alternativa al trabajo en local. Plantilla publicada en la galería, selección del compilador (LuaLaTeX), límites de compilación y solución de errores.
 - **[Contexto para IA](AI_CONTEXT.md)**: Referencia técnica completa para asistentes de IA (ChatGPT, Copilot, Claude, etc.).
 - **[Flujos de trabajo para IA](AI_WORKFLOWS.md)**: Guías paso a paso para las tareas más comunes (añadir capítulos, figuras, código, cambiar idioma, diagnosticar errores).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ Bienvenido a la documentación detallada de la plantilla TFG/TFM EPS Universidad
 ## 🚀 Guías de Inicio
 
 - **[Guía para Principiantes](GUIA_PRINCIPIANTES.md)**: Si es tu primera vez con LaTeX, empieza por aquí.
+- **[Uso en Overleaf](OVERLEAF.md)**: Plantilla publicada en la galería, selección del compilador (LuaLaTeX), límites de compilación y solución de errores.
 - **[Contexto para IA](AI_CONTEXT.md)**: Referencia técnica completa para asistentes de IA (ChatGPT, Copilot, Claude, etc.).
 - **[Flujos de trabajo para IA](AI_WORKFLOWS.md)**: Guías paso a paso para las tareas más comunes (añadir capítulos, figuras, código, cambiar idioma, diagnosticar errores).
 

--- a/docs/agents/redaccion-claude.md
+++ b/docs/agents/redaccion-claude.md
@@ -2,7 +2,7 @@
 
 Eres un experto en redacción académica en LaTeX para Trabajos de Fin de Grado
 (TFG) y Máster (TFM) de la Escuela Politécnica Superior (EPS) de la
-Universidad de Alicante (UA). Versión de plantilla: 2.2.1 (2026).
+Universidad de Alicante (UA). Versión de plantilla: 2.2.2 (2026).
 
 ---
 

--- a/docs/agents/revisor-claude.md
+++ b/docs/agents/revisor-claude.md
@@ -2,7 +2,7 @@
 
 Eres un tribunal académico experto en la evaluación de Trabajos de Fin de
 Grado (TFG) y Máster (TFM) de la Escuela Politécnica Superior (EPS) de la
-Universidad de Alicante (UA). Versión de plantilla: 2.2.1 (2026).
+Universidad de Alicante (UA). Versión de plantilla: 2.2.2 (2026).
 
 Tu misión es leer el documento del alumno y producir un informe de revisión
 estructurado, riguroso y constructivo, identificando problemas, inconsistencias

--- a/llms.txt
+++ b/llms.txt
@@ -38,6 +38,7 @@
 - [docs/REFERENCIAS_CRUZADAS.md](docs/REFERENCIAS_CRUZADAS.md): Etiquetas, referencias cruzadas y hyperref.
 - [docs/ACCESIBILIDAD.md](docs/ACCESIBILIDAD.md): PDFs accesibles (PDF/UA-2) con TeX Live 2025+.
 - [docs/GUIA_PRINCIPIANTES.md](docs/GUIA_PRINCIPIANTES.md): Guía de LaTeX para usuarios sin experiencia previa.
+- [docs/OVERLEAF.md](docs/OVERLEAF.md): Uso en Overleaf. Plantilla publicada en la galería, selección del compilador (LuaLaTeX obligatorio), versión de TeX Live, minted/shell-escape, límites de compilación y errores frecuentes.
 
 ## Herramientas de revisión automática
 

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Plantilla LaTeX para Trabajos de Fin de Grado (TFG) y Máster (TFM) de la
 > Escuela Politécnica Superior (EPS) de la Universidad de Alicante.
-> Versión 2.2.1 (2026). Motor: LuaLaTeX. Bibliografía: BibLaTeX + Biber (APA 7).
+> Versión 2.2.2 (2026). Motor: LuaLaTeX. Bibliografía: BibLaTeX + Biber (APA 7).
 
 ## Instrucciones para agentes de IA
 

--- a/main.tex
+++ b/main.tex
@@ -6,7 +6,7 @@
 %%
 %% Proyecto: Plantilla TFG/TFM EPS Universidad de Alicante
 %% Autor:    José Manuel Requena Plens
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %% =============================================================================
 %
 % Este es el archivo principal del documento.

--- a/scripts/revision-rapida.py
+++ b/scripts/revision-rapida.py
@@ -563,7 +563,7 @@ def verificar_plagio_turnitin(texto: str, api_key: str, tenant_url: str) -> list
     base_headers = {
         "Authorization": f"Bearer {api_key}",
         "X-Turnitin-Integration-Name": "TFG-TFM-EPS-UA",
-        "X-Turnitin-Integration-Version": "2.2.1",
+        "X-Turnitin-Integration-Version": "2.2.2",
     }
 
     def _request(method: str, path: str, body=None, binary: bool = False) -> dict:

--- a/sty/componentes/eps-arquitectura.sty
+++ b/sty/componentes/eps-arquitectura.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-arquitectura.sty}[2026/07/11 v2.2.1 Componentes arquitectura EPS UA]
+\ProvidesFile{eps-arquitectura.sty}[2026/08/02 v2.2.2 Componentes arquitectura EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-comunes.sty
+++ b/sty/componentes/eps-comunes.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-comunes.sty}[2026/07/11 v2.2.1 Componentes comunes EPS UA]
+\ProvidesFile{eps-comunes.sty}[2026/08/02 v2.2.2 Componentes comunes EPS UA]
 
 % ============================================================================
 % CAJAS DE INFORMACIÓN

--- a/sty/componentes/eps-geologia.sty
+++ b/sty/componentes/eps-geologia.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-geologia.sty}[2026/07/11 v2.2.1 Componentes geología EPS UA]
+\ProvidesFile{eps-geologia.sty}[2026/08/02 v2.2.2 Componentes geología EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-prevencion.sty
+++ b/sty/componentes/eps-prevencion.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-prevencion.sty}[2026/07/11 v2.2.1 Componentes prevención EPS UA]
+\ProvidesFile{eps-prevencion.sty}[2026/08/02 v2.2.2 Componentes prevención EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-quimica.sty
+++ b/sty/componentes/eps-quimica.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-quimica.sty}[2026/07/11 v2.2.1 Componentes química EPS UA]
+\ProvidesFile{eps-quimica.sty}[2026/08/02 v2.2.2 Componentes química EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-software.sty
+++ b/sty/componentes/eps-software.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-software.sty}[2026/07/11 v2.2.1 Componentes software EPS UA]
+\ProvidesFile{eps-software.sty}[2026/08/02 v2.2.2 Componentes software EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/componentes/eps-telecom.sty
+++ b/sty/componentes/eps-telecom.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Parte de eps-componentes.sty
 %% -----------------------------------------------------------------------------
-\ProvidesFile{eps-telecom.sty}[2026/07/11 v2.2.1 Componentes telecom EPS UA]
+\ProvidesFile{eps-telecom.sty}[2026/08/02 v2.2.2 Componentes telecom EPS UA]
 
 % ============================================================================
 % DEPENDENCIAS

--- a/sty/eps-codigo.sty
+++ b/sty/eps-codigo.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{eps-codigo}[2026/07/11 v2.2.1 Estilos de código TFG/TFM EPS UA]
+\ProvidesPackage{eps-codigo}[2026/08/02 v2.2.2 Estilos de código TFG/TFM EPS UA]
 
 %% NOTA IMPORTANTE:
 %% Este paquete depende de 'minted', que a su vez requiere Python y Pygments instalado.

--- a/sty/eps-componentes.sty
+++ b/sty/eps-componentes.sty
@@ -5,7 +5,7 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% Uso:
 %%   \usepackage{eps-componentes}                    % Carga solo comunes
@@ -17,7 +17,7 @@
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{eps-componentes}[2026/07/11 v2.2.1 Componentes especializados EPS UA]
+\ProvidesPackage{eps-componentes}[2026/08/02 v2.2.2 Componentes especializados EPS UA]
 
 % ============================================================================
 % OPCIONES DEL PAQUETE (Modernizado con l3keys)

--- a/sty/eps-portadas.sty
+++ b/sty/eps-portadas.sty
@@ -5,11 +5,11 @@
 %% Autor:    José Manuel Requena Plens
 %% Enlace:   https://github.com/jmrplens/TFG-TFM_EPS
 %% Licencia: MIT
-%% Versión:  2.2.1 (2026/07/11)
+%% Versión:  2.2.2 (2026/08/02)
 %%
 %% -----------------------------------------------------------------------------
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{eps-portadas}[2026/07/11 v2.2.1 Portadas TFG/TFM EPS Universidad de Alicante]
+\ProvidesPackage{eps-portadas}[2026/08/02 v2.2.2 Portadas TFG/TFM EPS Universidad de Alicante]
 
 \RequirePackage{xparse}
 \RequirePackage{tikz}


### PR DESCRIPTION
## Descripción

Un proyecto importado a Overleaf no compilaba: fallaba con
`TeX capacity exceeded, sorry [main memory size=5000000]` justo en
`\begin{document}`.

**Causa:** Overleaf ignora la línea mágica `% !TeX program = lualatex` de
`main.tex` y elige el motor desde *Menu → Compiler*, pasándolo por línea de
órdenes, lo que tiene **prioridad sobre `$pdf_mode` del `.latexmkrc`**. El
proyecto se compilaba con XeLaTeX, cuya memoria principal es fija y no admite
el preámbulo de esta plantilla (tagging PDF/UA + KOMA + biblatex + glossaries +
tcolorbox + minted + módulos de componentes).

Los demás avisos que aparecían en el panel de logs (hyperxmp deshabilitado,
`tracklang`/`datatool`, `You have requested package sty/...`, `output.ist not
found`) son inofensivos: aparecen igual en una compilación local correcta.

### Cambios

- **`.latexmkrc`**: `$pdflatex`, `$xelatex` y `$latex` redirigidos a LuaLaTeX.
  El proyecto compila en Overleaf aunque el menú *Compiler* no esté en
  LuaLaTeX. En la compilación normal (`$pdf_mode = 4`) estas variables no se
  usan, así que `make` y el CI no cambian de comportamiento.
- **`cls/eps-metadata.tex` y `cls/eps-tfg.cls`**: comprobación de motor. Con
  pdfLaTeX o XeLaTeX la compilación se detiene con un mensaje explicativo en
  lugar del error críptico de memoria.
- **`docs/OVERLEAF.md`** (nuevo): importación, selección de compilador, versión
  de TeX Live, minted/shell-escape, límites de compilación con estrategia de
  compilación progresiva, avisos inofensivos y tabla de errores frecuentes.
- **Plantilla publicada en la galería de Overleaf** enlazada desde README,
  `docs/OVERLEAF.md`, `docs/README.md`, `docs/GUIA_PRINCIPIANTES.md` y
  `llms.txt` (además, faltaba indexar la guía nueva en esos índices).
- **Tablas de diagnóstico** de `CLAUDE.md`, `AGENTS.md` y
  `.github/copilot-instructions.md`: fila para `TeX capacity exceeded`.
- **Versión**: bump 2.2.1 → 2.2.2 y fecha 2026/07/11 → 2026/08/02 en todos los
  marcadores (cabeceras `.cls`/`.sty` y `\ProvidesXXX`, `main.tex`,
  `configuracion.tex`, `Makefile`, `llms.txt`, `CITATION.cff`, badge del
  README, `docs/agents`, `.herramientas`, `scripts/revision-rapida.py`).

## Tipo de cambio

- [x] 🐛 Corrección de bug (cambio que soluciona un problema)
- [ ] ✨ Nueva funcionalidad (cambio que añade funcionalidad)
- [ ] 💥 Cambio importante (fix o feature que causaría que funcionalidad existente deje de funcionar)
- [x] 📝 Documentación (cambios solo en documentación)
- [ ] 🎨 Estilo (cambios que no afectan al significado del código: formato, espacios, etc.)
- [ ] ♻️ Refactorización (cambio de código que no corrige bugs ni añade funcionalidades)
- [ ] 🎓 Nueva titulación (añade soporte para una nueva titulación)

## ¿Cómo se ha probado?

- [x] He compilado el documento completo con `make` sin errores
- [x] He verificado que el PDF se genera correctamente
- [x] He probado en mi sistema: Debian, TeX Live 2025, LuaHBTeX 1.18.0

Pruebas realizadas:

1. **Reproducción del fallo de Overleaf**: simulando su invocación exacta con
   XeLaTeX seleccionado (`latexmk -pdfxe -f -jobname=output -synctex=1
   -interaction=batchmode -recorder main.tex`) sobre una copia limpia del
   repositorio → **exit 0 y PDF de 153 páginas**, con bibliografía, glosario y
   acrónimos resueltos. Sin el cambio, ese mismo comando es el que fallaba.
2. **Otros ajustes del menú de Overleaf**: probados también `-pdf` (pdfLaTeX) y
   `-pdfdvi` (LaTeX); los tres acaban ejecutando LuaLaTeX.
3. **Compilación normal del repositorio** con los guards puestos: exit 0,
   153 páginas.
4. **Guards**: `xelatex` y `pdflatex` directos se detienen en segundos con el
   mensaje `ESTA PLANTILLA REQUIERE LuaLaTeX`; la clase muestra el
   `ClassError` equivalente si se carga sin `cls/eps-metadata.tex`.

Efecto secundario conocido: si el menú de Overleaf se deja en XeLaTeX, en los
logs aparece `lualatex: unrecognized option '-no-pdf'` (lualatex lo ignora y
continúa) y latexmk hace una pasada extra al detectar que la salida es PDF y no
XDV. Por eso la documentación sigue recomendando seleccionar LuaLaTeX.

## Checklist

- [x] Mi código sigue las guías de estilo de este proyecto
- [x] He realizado una auto-revisión de mi código
- [x] He comentado mi código, especialmente en áreas difíciles de entender
- [x] He actualizado la documentación correspondiente (README, CHANGELOG, etc.)
- [x] Mis cambios no generan nuevos warnings durante la compilación
- [x] He añadido una entrada al CHANGELOG.md si procede

## Información adicional

Tiempos medidos en local (documento de ejemplo completo), relevantes para los
límites de compilación de Overleaf (~20 s en gratuito, 240 s en premium):

| Variante | Páginas | Desde cero | Recompilación |
| --- | --- | --- | --- |
| Repo completo (`[all]` + 7 capítulos) | 153 | varios minutos (4-5 pasadas) | ~75-95 s |
| Esqueleto (`[software]` + 1 capítulo) | 27 | 56 s (2 pasadas) | ~31 s |

No se toca `main.pdf` (igual que en los bumps de versión anteriores).

https://claude.ai/code/session_01Epzb5ew6f4SZADUzy9nJd3


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/jmrplens/TFG-TFM_EPS/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuevas funcionalidades**
  - Añadido soporte y guía completa para usar la plantilla en Overleaf.
  - Incorporadas instrucciones para configurar LuaLaTeX, TeX Live y `shell-escape`.
  - Las compilaciones con motores incompatibles se redirigen automáticamente a LuaLaTeX cuando es posible.

- **Correcciones**
  - Se añadieron comprobaciones y mensajes de diagnóstico para errores de compilación y límites de memoria.
  - Mejorada la compatibilidad con configuraciones de compilación habituales.

- **Documentación**
  - Actualizada la información de uso, resolución de problemas y registro de cambios.

- **Mantenimiento**
  - Actualizada la versión a 2.2.2 (2 de agosto de 2026).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->